### PR TITLE
fix(patch_desired): duplicate desiredmatches

### DIFF
--- a/examples/patch_desired/patching/README.md
+++ b/examples/patch_desired/patching/README.md
@@ -13,27 +13,6 @@ kind: XSubnetwork
 metadata:
   name: test-xrender
 ---
-apiVersion: s3.aws.upbound.io/v1beta1
-kind: Bucket
-metadata:
-  annotations:
-    crossplane.io/composition-resource-name: prime-objects-test-bucket
-  generateName: test-xrender-
-  labels:
-    crossplane.io/composite: test-xrender
-  name: test-bucket
-  ownerReferences:
-  - apiVersion: nopexample.org/v1
-    blockOwnerDeletion: true
-    controller: true
-    kind: XSubnetwork
-    name: test-xrender
-    uid: ""
-spec:
-  forProvider:
-    policy: some-bucket-policy
-    region: us-east-2
----
 apiVersion: ec2.aws.upbound.io/v1beta1
 kind: Instance
 metadata:
@@ -54,6 +33,29 @@ spec:
   forProvider:
     ami: ami-0d9858aa3c6322f73
     instanceType: t2.micro
+    region: us-east-2
+---
+apiVersion: s3.aws.upbound.io/v1beta1
+kind: Bucket
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: prime-objects-test-bucket
+    nobu.dev/app: someapp
+    nobu.dev/cueified: "true"
+  generateName: test-xrender-
+  labels:
+    crossplane.io/composite: test-xrender
+  name: test-bucket
+  ownerReferences:
+  - apiVersion: nopexample.org/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XSubnetwork
+    name: test-xrender
+    uid: ""
+spec:
+  forProvider:
+    policy: some-bucket-policy
     region: us-east-2
 ---
 apiVersion: xrender.crossplane.io/v1beta1

--- a/examples/patch_desired/patching/README.md
+++ b/examples/patch_desired/patching/README.md
@@ -5,11 +5,6 @@
 $ xrender xr.yaml composition.yaml functions.yaml
 ```
 
-**Note**
-
-I think there is a bug with xrender somewhere, i will submit an issue once i know more, but it does not produce the most recent version of the desired resource
-But for some reason produces the previous version.  Logs and the fn_tests in this repo seem to indicate desired patching works but the xrender does not look right
-
 #### Produces
 ```yaml
 ---

--- a/fn.go
+++ b/fn.go
@@ -135,6 +135,7 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1beta1.RunFunctionRequ
 	// Based on the input target
 	// Store the objects into the output object
 	// For success messages later
+	// TODO move this giant switch into some other function
 	log.Info("Setting output to target")
 	output := successOutput{
 		target: in.Export.Target,
@@ -187,18 +188,12 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1beta1.RunFunctionRequ
 			return rsp, nil
 		}
 
-		for dr, d := range desiredMatches {
-			conf.basename = dr.Resource.GetName()
-			conf.data = d
-			if err := addResourcesTo(desiredMatches, conf); err != nil {
-				response.Fatal(rsp, errors.Wrapf(err, "cannot add resources to DesiredComposed"))
-				return rsp, nil
-			}
+		if err := addResourcesTo(desiredMatches, conf); err != nil {
+			response.Fatal(rsp, errors.Wrapf(err, "cannot add resources to DesiredComposed"))
+			return rsp, nil
 		}
 		output.object = cmpOut.data
 		output.msgCount = len(cmpOut.data)
-		//output.object = data
-		//output.msgCount = len(data)
 	case v1beta1.Resources:
 		conf.basename = in.Name
 		conf.data = cmpOut.data
@@ -212,7 +207,7 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1beta1.RunFunctionRequ
 		output.msgCount = len(cmpOut.data)
 	}
 
-	// Get the connection details and propogate them to the xr
+	// Get the connection details and propagate them to the xr
 	conn, err := extractConnectionDetails(observed, cmpOut.connectionData)
 	if err != nil {
 		response.Fatal(rsp, errors.Wrap(err, "cannot get connection details from ObservedComposed"))


### PR DESCRIPTION
### What and Why?

Fix a bug i introduced in [another pr](https://github.com/Mitsuwa/function-cue/pull/31) for multiple patch desired resources.

This was adding duplicate entries because it was looping over desiredMatches twice, remove this additional call to addResources.  This wasnt caught because there wasnt a test for desired matching patching multiple objects, i have added a test for it now

I have:

- [x] Read and followed the [Contribution guide](../docs/CONTRIBUTING.md).
- [x] Added or updated unit tests for my change.
