### PR TITLE
fix(logging): Panic from debug and Remove template.fn from function-cue

### DIFF
--- a/docs/CONFIGMAPS.md
+++ b/docs/CONFIGMAPS.md
@@ -21,7 +21,7 @@ spec:
       functionRef:
         name: function-cue
       input:
-        apiVersion: template.fn.crossplane.io/v1beta1
+        apiVersion: cue.fn.crossplane.io/v1beta1
         kind: CUEInput
         metadata:
           name: basic

--- a/docs/EXPORT_OPTIONS.md
+++ b/docs/EXPORT_OPTIONS.md
@@ -21,7 +21,7 @@ spec:
     functionRef:
       name: function-cue
     input:
-      apiVersion: template.fn.crossplane.io/v1beta1
+      apiVersion: cue.fn.crossplane.io/v1beta1
       kind: CUEInput
       metadata:
         name: basic
@@ -58,7 +58,7 @@ spec:
     functionRef:
       name: function-cue
     input:
-      apiVersion: template.fn.crossplane.io/v1beta1
+      apiVersion: cue.fn.crossplane.io/v1beta1
       kind: CUEInput
       metadata:
         name: basic

--- a/docs/MERGING_VALUES.md
+++ b/docs/MERGING_VALUES.md
@@ -19,7 +19,7 @@ spec:
     functionRef:
       name: function-cue
     input:
-      apiVersion: template.fn.crossplane.io/v1beta1
+      apiVersion: cue.fn.crossplane.io/v1beta1
       kind: CUEInput
       metadata:
         name: basic

--- a/docs/TARGETING_OBJECTS.md
+++ b/docs/TARGETING_OBJECTS.md
@@ -29,7 +29,7 @@ spec:
     functionRef:
       name: function-cue
     input:
-      apiVersion: template.fn.crossplane.io/v1beta1
+      apiVersion: cue.fn.crossplane.io/v1beta1
       kind: CUEInput
       metadata:
         name: basic

--- a/examples/patch_desired/README.md
+++ b/examples/patch_desired/README.md
@@ -7,7 +7,3 @@ The documents generated must have an `apiVersion`, `kind` and `name` associated 
 This apiVersion+kind+name is used to match the `DesiredComposed` resources.
 
 If the patch count does not match the number of generated documents (not found documents), `function-cue` will error
-
-### TODO
-
-- Merging annotations and labels - see meta.AddAnnotations and meta.AddLabels

--- a/examples/patch_desired/patching/composition.yaml
+++ b/examples/patch_desired/patching/composition.yaml
@@ -12,7 +12,7 @@ spec:
     functionRef:
       name: function-cue
     input:
-      apiVersion: template.fn.crossplane.io/v1beta1
+      apiVersion: cue.fn.crossplane.io/v1beta1
       kind: CUEInput
       metadata:
         name: prime-objects
@@ -42,7 +42,7 @@ spec:
     functionRef:
       name: function-cue
     input:
-      apiVersion: template.fn.crossplane.io/v1beta1
+      apiVersion: cue.fn.crossplane.io/v1beta1
       kind: CUEInput
       metadata:
         name: patch-xr

--- a/examples/patch_resources/README.md
+++ b/examples/patch_resources/README.md
@@ -7,7 +7,3 @@ The documents generated must have an `apiVersion`, `kind` and `name` associated 
 This apiVersion+kind+name is used to match the `CUEInput.Export.Resources` resources.
 
 If the patch count does not match the number of generated documents (not found documents), `function-cue` will error
-
-### TODO
-
-- Merging annotations and labels

--- a/examples/patch_resources/patching/composition.yaml
+++ b/examples/patch_resources/patching/composition.yaml
@@ -12,7 +12,7 @@ spec:
     functionRef:
       name: function-cue
     input:
-      apiVersion: template.fn.crossplane.io/v1beta1
+      apiVersion: cue.fn.crossplane.io/v1beta1
       kind: CUEInput
       metadata:
         name: patch-xr

--- a/examples/patch_resources/patching_multiple/composition.yaml
+++ b/examples/patch_resources/patching_multiple/composition.yaml
@@ -12,7 +12,7 @@ spec:
     functionRef:
       name: function-cue
     input:
-      apiVersion: template.fn.crossplane.io/v1beta1
+      apiVersion: cue.fn.crossplane.io/v1beta1
       kind: CUEInput
       metadata:
         name: patch-xr

--- a/examples/resources/conditionals/composition.yaml
+++ b/examples/resources/conditionals/composition.yaml
@@ -12,7 +12,7 @@ spec:
     functionRef:
       name: function-cue
     input:
-      apiVersion: template.fn.crossplane.io/v1beta1
+      apiVersion: cue.fn.crossplane.io/v1beta1
       kind: CUEInput
       metadata:
         name: conditional

--- a/examples/resources/identifiers/composition.yaml
+++ b/examples/resources/identifiers/composition.yaml
@@ -12,7 +12,7 @@ spec:
     functionRef:
       name: function-cue
     input:
-      apiVersion: template.fn.crossplane.io/v1beta1
+      apiVersion: cue.fn.crossplane.io/v1beta1
       kind: CUEInput
       metadata:
         name: identifier

--- a/examples/resources/injections/composition.yaml
+++ b/examples/resources/injections/composition.yaml
@@ -12,7 +12,7 @@ spec:
     functionRef:
       name: function-cue
     input:
-      apiVersion: template.fn.crossplane.io/v1beta1
+      apiVersion: cue.fn.crossplane.io/v1beta1
       kind: CUEInput
       metadata:
         name: injections

--- a/examples/resources/multipleresources/composition.yaml
+++ b/examples/resources/multipleresources/composition.yaml
@@ -12,7 +12,7 @@ spec:
     functionRef:
       name: function-cue
     input:
-      apiVersion: template.fn.crossplane.io/v1beta1
+      apiVersion: cue.fn.crossplane.io/v1beta1
       kind: CUEInput
       metadata:
         name: multiple-objects

--- a/examples/xr/patching/composition.yaml
+++ b/examples/xr/patching/composition.yaml
@@ -12,7 +12,7 @@ spec:
     functionRef:
       name: function-cue
     input:
-      apiVersion: template.fn.crossplane.io/v1beta1
+      apiVersion: cue.fn.crossplane.io/v1beta1
       kind: CUEInput
       metadata:
         name: patch-xr

--- a/fn.go
+++ b/fn.go
@@ -219,7 +219,7 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1beta1.RunFunctionRequ
 	}
 
 	// Set dxr and desired state
-	log.Debug("Setting desired XR state to %+v", dxr.Resource)
+	log.Debug(fmt.Sprintf("Setting desired XR state to %+v", dxr.Resource))
 	if err := response.SetDesiredCompositeResource(rsp, dxr); err != nil {
 		response.Fatal(rsp, errors.Wrapf(err, "cannot set desired composite resource in %T", rsp))
 		return rsp, nil


### PR DESCRIPTION
### What and Why?

Fixes #40 

You can see this `template.` no longer exists in this repo and the tests are passing.

The CUEInput type and generated input already use this `https://github.com/crossplane-contrib/function-cue/tree/main/package/input`. It is a little curious that xrender was able to render the previous example input with the wrong apiVersion, im assuming that must mean that it is not utilizing the version?

```
 $ git grep "template\."
 
 ```
 
 This also fixes a debug panic i introduced in a previous pr because i was passing a formatted string and not just a string, i didnt notice this because it only occurs when run with `--debug`

I have:

- [x] Read and followed the [Contribution guide](../docs/CONTRIBUTING.md).
- [x] Added or updated unit tests for my change.
