### PR TITLE
Additional testing, Mitsuwa -> crossplane-contrib org, 

### DIFF
--- a/cue.go
+++ b/cue.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Mitsuwa/function-cue/input/v1beta1"
+	"github.com/crossplane-contrib/function-cue/input/v1beta1"
 
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/ast"

--- a/cue_test.go
+++ b/cue_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/Mitsuwa/function-cue/input/v1beta1"
+	"github.com/crossplane-contrib/function-cue/input/v1beta1"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -27,6 +27,7 @@ var testTable = []struct {
 	{outputJSON, "out: 3 * \"blah\"", "{\n    \"out\": \"blahblahblah\"\n}\n", []string{}, []string{}},
 	{outputJSON, "out: 3 * [1, 2, 3]", "{\n    \"out\": [\n        1,\n        2,\n        3,\n        1,\n        2,\n        3,\n        1,\n        2,\n        3\n    ]\n}\n", []string{}, []string{}},
 	{outputJSON, "out: 3 > 8", "{\n    \"out\": false\n}\n", []string{}, []string{}},
+	{outputJSON, "x: \"\\(y._y)-bar\"\nlet y = {\n\t_y: \"foo\"\n}\n", "{\n    \"x\": \"foo-bar\"\n}\n", []string{}, []string{}},
 	{outputJSON, "#out: \"test\"", "{}\n", []string{}, []string{}},
 	{outputJSON, "#test: \"somestring\"\n\nout: \"this-is-concatting-\\(#test)\"\n", "{\n    \"out\": \"this-is-concatting-somestring\"\n}\n", []string{}, []string{}},
 	{outputJSON, "val: number @tag(val,type=int)\n", "{\n    \"val\": 3.14\n}\n", []string{}, []string{"val=3.14"}},
@@ -96,6 +97,7 @@ var testFailTable = []struct {
 	{outputJSON, "package inject\n\n// @tag() is how we inject data\nenv:      *\"dev\" | string @tag(env)      // env has a default\ndatabase: string          @tag(database) // database is \"required\"\n\n// A schema for DBs with some defaults\n#DB: {\n\thost: #hosts[env]\n\tport: string | *\"5432\"\n\tdb:   database\n\n\t// interpolate the fields into the connection string\n\tconn: \"postgres://\\(host):\\(port)/\\(db)\"\n}\n\n// setup our database host mapping\n#hosts: [string]: string\n#hosts: {\n\tdev: \"postgres.dev\"\n\tstg: \"postgres.stg\"\n\tprd: \"postgres.prd\"\n}\n", "failed creating cue compiler: failed to validate: database: incomplete value string", []string{}},
 	{outputJSON, "val: number @tag(val,type=int)\n", "failed creating cue compiler: failed to validate: val: incomplete value number", []string{}},
 	{outputJSON, "env: string @tag(env,short=prod|staging)", "failed creating cue compiler: failed to validate: env: incomplete value string", []string{}},
+	{outputJSON, "x: \"\\(_y)-bar\"\n{\n\t_y: \"foo\"\n}\n", "failed creating cue compiler: failed to build: reference \"_y\" not found", []string{}},
 }
 
 // TestCUECompileFailures for failure strings, do not attempt to parse data in these tests

--- a/fn_test.go
+++ b/fn_test.go
@@ -7,11 +7,16 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	fnv1beta1 "github.com/crossplane/function-sdk-go/proto/v1beta1"
 	"github.com/crossplane/function-sdk-go/resource"
+	"github.com/crossplane/function-sdk-go/resource/composed"
+	"github.com/crossplane/function-sdk-go/resource/composite"
 	"github.com/crossplane/function-sdk-go/response"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/durationpb"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func TestRunFunction(t *testing.T) {
@@ -2017,6 +2022,366 @@ func TestRunFunctionFailures(t *testing.T) {
 			rsp, err := f.RunFunction(tc.args.ctx, tc.args.req)
 
 			if diff := cmp.Diff(tc.want.rsp, rsp, protocmp.Transform()); diff != "" {
+				t.Errorf("%s\nf.RunFunction(...): -want rsp, +got rsp:\n%s", tc.reason, diff)
+			}
+
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("%s\nf.RunFunction(...): -want err, +got err:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestSetData(t *testing.T) {
+
+	type args struct {
+		data      map[string]interface{}
+		on        any
+		overwrite bool
+	}
+	type want struct {
+		err error
+		out any
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"DesiredComposedBasic": {
+			reason: "DesiredComposed should be able to set basic data",
+			args: args{
+				data: map[string]interface{}{
+					"kind": "testkind",
+					"metadata": map[string]interface{}{
+						"name": "testname",
+						"annotations": map[string]interface{}{
+							"nobu.dev/app": "someapp",
+						},
+					},
+					"spec": map[string]interface{}{
+						"forProvider": map[string]interface{}{
+							"something": "somevalue",
+						},
+					},
+				},
+				on: &resource.DesiredComposed{
+					Resource: composed.New(),
+				},
+			},
+			want: want{
+				out: &resource.DesiredComposed{
+					Resource: &composed.Unstructured{
+						Unstructured: unstructured.Unstructured{
+							Object: map[string]interface{}{
+								"metadata": map[string]interface{}{
+									"annotations": map[string]interface{}{
+										"nobu.dev/app": "someapp",
+									},
+								},
+								"spec": map[string]interface{}{
+									"forProvider": map[string]interface{}{
+										"something": "somevalue",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"DesiredComposedDeeperCopies": {
+			reason: "DesiredComposed should be able to set basic data",
+			args: args{
+				data: map[string]interface{}{
+					"apiVersion": "nobu.dev/v1",
+					"kind":       "brother",
+					"metadata": map[string]interface{}{
+						"name": "ignored",
+						"annotations": map[string]interface{}{
+							"nobu.dev/app": "someapp",
+						},
+					},
+					"spec": map[string]interface{}{
+						"forProvider": map[string]interface{}{
+							"something": "somevalue",
+							"network":   "network",
+							"clusterRef": map[string]interface{}{
+								"name": "example-cluster",
+							},
+						},
+						"template": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"metadata": map[string]interface{}{
+									"name": "testname",
+									"labels": map[string]interface{}{
+										"kubernetes.io/serviceaccount": "sa",
+										"kubernetes.io/rbac":           "variant",
+									},
+								},
+								"env": []string{
+									"env1=env1val",
+									"env2=env2val",
+								},
+							},
+						},
+					},
+				},
+				on: &resource.DesiredComposed{
+					Resource: composed.New(),
+				},
+			},
+			want: want{
+				out: &resource.DesiredComposed{
+					Resource: &composed.Unstructured{
+						Unstructured: unstructured.Unstructured{
+							Object: map[string]interface{}{
+								"metadata": map[string]interface{}{
+									"annotations": map[string]interface{}{
+										"nobu.dev/app": "someapp",
+									},
+								},
+								"spec": map[string]interface{}{
+									"forProvider": map[string]interface{}{
+										"something": "somevalue",
+										"network":   "network",
+										"clusterRef": map[string]interface{}{
+											"name": "example-cluster",
+										},
+									},
+									"template": map[string]interface{}{
+										"spec": map[string]interface{}{
+											"metadata": map[string]interface{}{
+												"name": "testname",
+												"labels": map[string]interface{}{
+													"kubernetes.io/serviceaccount": "sa",
+													"kubernetes.io/rbac":           "variant",
+												},
+											},
+											"env": []any{
+												"env1=env1val",
+												"env2=env2val",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"XRBasic": {
+			reason: "XR should be able to set basic data",
+			args: args{
+				data: map[string]interface{}{
+					"apiVersion": "nobu.dev/v1",
+					"kind":       "testkind",
+					"metadata": map[string]interface{}{
+						"name": "testname",
+						"annotations": map[string]interface{}{
+							"nobu.dev/app": "someapp",
+						},
+					},
+					"spec": map[string]interface{}{
+						"forProvider": map[string]interface{}{
+							"something": "somevalue",
+						},
+					},
+				},
+				on: &resource.Composite{
+					Resource: composite.New(),
+				},
+			},
+			want: want{
+				out: &resource.Composite{
+					Resource: &composite.Unstructured{
+						Unstructured: unstructured.Unstructured{
+							Object: map[string]interface{}{
+								// XR sets gvk+name
+								"apiVersion": "nobu.dev/v1",
+								"kind":       "testkind",
+								"metadata": map[string]interface{}{
+									"name": "testname",
+									"annotations": map[string]interface{}{
+										"nobu.dev/app": "someapp",
+									},
+								},
+								"spec": map[string]interface{}{
+									"forProvider": map[string]interface{}{
+										"something": "somevalue",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"XROverwrite": {
+			reason: "XR should be able to set overwrite data",
+			args: args{
+				data: map[string]interface{}{
+					"kind": "testkind",
+					"metadata": map[string]interface{}{
+						"name": "testname",
+						"annotations": map[string]interface{}{
+							"nobu.dev/app": "someapp",
+						},
+					},
+					"spec": map[string]interface{}{
+						"forProvider": map[string]interface{}{
+							"something": "somevalue",
+						},
+					},
+				},
+				on: &resource.Composite{
+					Resource: &composite.Unstructured{
+						Unstructured: unstructured.Unstructured{
+							Object: map[string]interface{}{
+								"kind": "overwriteme",
+							},
+						},
+					},
+				},
+				overwrite: true,
+			},
+			want: want{
+				out: &resource.Composite{
+					Resource: &composite.Unstructured{
+						Unstructured: unstructured.Unstructured{
+							Object: map[string]interface{}{
+								"kind": "testkind",
+								"metadata": map[string]interface{}{
+									"name": "testname",
+									"annotations": map[string]interface{}{
+										"nobu.dev/app": "someapp",
+									},
+								},
+								"spec": map[string]interface{}{
+									"forProvider": map[string]interface{}{
+										"something": "somevalue",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"XRDeeperCopy": {
+			reason: "DesiredComposed should be able to set data at many levels without conflictions",
+			args: args{
+				data: map[string]interface{}{
+					"apiVersion": "nobu.dev/v1",
+					"kind":       "brother",
+					"metadata": map[string]interface{}{
+						"annotations": map[string]interface{}{
+							"nobu.dev/app": "someapp",
+						},
+					},
+					"spec": map[string]interface{}{
+						"forProvider": map[string]interface{}{
+							"network": "network",
+							"clusterRef": map[string]interface{}{
+								"name": "example-cluster",
+							},
+						},
+						"template": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"metadata": map[string]interface{}{
+									"name": "testname",
+									"labels": map[string]interface{}{
+										"kubernetes.io/rbac": "variant",
+									},
+								},
+								"env": []string{
+									"env1=env1val",
+									"env2=env2val",
+								},
+							},
+						},
+					},
+				},
+				on: &resource.Composite{
+					Resource: &composite.Unstructured{
+						Unstructured: unstructured.Unstructured{
+							Object: map[string]interface{}{
+								"metadata": map[string]interface{}{
+									"name": "whatsinaname",
+								},
+								"spec": map[string]interface{}{
+									"forProvider": map[string]interface{}{
+										"another":   "existing",
+										"something": "someothervalue",
+									},
+									"template": map[string]interface{}{
+										"spec": map[string]interface{}{
+											"metadata": map[string]interface{}{
+												"labels": map[string]interface{}{
+													"kubernetes.io/serviceaccount": "sa",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				out: &resource.Composite{
+					Resource: &composite.Unstructured{
+						Unstructured: unstructured.Unstructured{
+							Object: map[string]interface{}{
+								"apiVersion": "nobu.dev/v1",
+								"kind":       "brother",
+								"metadata": map[string]interface{}{
+									"name": "whatsinaname",
+									"annotations": map[string]interface{}{
+										"nobu.dev/app": "someapp",
+									},
+								},
+								"spec": map[string]interface{}{
+									"forProvider": map[string]interface{}{
+										"another":   "existing",
+										"network":   "network",
+										"something": "someothervalue",
+										"clusterRef": map[string]interface{}{
+											"name": "example-cluster",
+										},
+									},
+									"template": map[string]interface{}{
+										"spec": map[string]interface{}{
+											"metadata": map[string]interface{}{
+												"name": "testname",
+												"labels": map[string]interface{}{
+													"kubernetes.io/serviceaccount": "sa",
+													"kubernetes.io/rbac":           "variant",
+												},
+											},
+											"env": []any{
+												"env1=env1val",
+												"env2=env2val",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := setData(tc.args.data, "", tc.args.on, tc.args.overwrite)
+
+			if diff := cmp.Diff(tc.want.out, tc.args.on, protocmp.Transform()); diff != "" {
 				t.Errorf("%s\nf.RunFunction(...): -want rsp, +got rsp:\n%s", tc.reason, diff)
 			}
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Mitsuwa/function-cue
+module github.com/crossplane-contrib/function-cue
 
 go 1.20
 


### PR DESCRIPTION
### What and Why?

Add setData tests, a couple cue compilation tests that test scope,  and fn tests

update imports from `Mitsuwa` to `crossplane-contrib`, setData checks for nil Resource and returns error, it was currently panicking if the resource hadnt been created yet

I have:

- [x] Read and followed the [Contribution guide](../docs/CONTRIBUTING.md).
- [x] Added or updated unit tests for my change.
