### PR TITLE
Update Output Schema for cue compilation, include base, name, connectionDetails, readiness checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ Ex `cueCompile()` output schema
 
 #### json
 `single`
-
 ```json
 {
   "name": "my-cluster",

--- a/README.md
+++ b/README.md
@@ -33,48 +33,70 @@ See [examples folder](examples)
 The compilation output of the `CUEInput.Export.Value` **must** be in `YAML` or `JSON` documents, or it will fail parsing.
 
 - Each document produced should be a valid crossplane resource `xr` or `mr`
-- Each document must have an `apiVersion`, `kind`, and `metadata.name`
+- Each document must have an `apiVersion`, `kind`
 
-Ex `cueCompile()` output
+Ex `cueCompile()` output schema
+
+```cue
+#outputSchema: {
+	// Name of your resource
+	name: string
+	// Optional connection details
+	// see docs/CONNECTION_DETAILS.md for more details
+	connectionDetails?: [...#connectionDetail]
+	// Optional readiness checks
+	// see docs/READINESS_CHECKS.md for more details
+	readinessChecks?: [...#readinessCheck]
+	// Resource spec
+	base: {
+		// Example
+		// apiVersion: "nobu.dev/v1"
+		// kind: "Example"
+		//
+		// etc...
+	}
+}
+```
 
 #### json
 `single`
+
 ```json
 {
-  "apiVersion": "nobu.dev/v1",
-  "kind": "XCluster",
-  "metadata": {
-    "name": "my-cluster"
+  "name": "my-cluster",
+  "base": {
+    "apiVersion": "nobu.dev/v1",
+    "kind": "XCluster"
   }
 }
 ```
 
 `multiple` - single json document per line, `-e json.MarshalStream(field)` will produce this format
 ```json
-{"apiVersion": "nobu.dev/v1", "kind": "XCluster", "metadata": {"name": "my-cluster"}}
-{"apiVersion": "nobu.dev/v1", "kind": "XNetwork", "metadata": {"name": "my-network"}}
+{"name": "my-cluster", "base": {"apiVersion": "nobu.dev/v1", "kind": "XCluster"}}
+{"name": "my-network", "base": {"apiVersion": "nobu.dev/v1", "kind": "XNetwork"}}
 ```
 
 #### yaml
 `single`
 ```yaml
-apiVersion: "nobu.dev/v1"
-kind: "XCluster"
-metadata:
-  name: "my-cluster"
+name: "my-cluster"
+base:
+  apiVersion: "nobu.dev/v1"
+  kind: "XCluster"
 ```
 
 `multiple` documents, separated by `---`, `-e yaml.MarshalStream(field)` will produce this format
 ```yaml
-apiVersion: "nobu.dev/v1"
-kind: "XCluster"
-metadata:
-  name: "my-cluster"
+name: "my-cluster"
+base:
+  apiVersion: "nobu.dev/v1"
+  kind: "XCluster"
 ---
-apiVersion: "nobu.dev/v1"
-kind: "XNetwork"
-metadata:
-  name: "my-network"
+name: "my-network"
+base:
+  apiVersion: "nobu.dev/v1"
+  kind: "XNetwork"
 ...
 ```
 
@@ -98,7 +120,7 @@ kind: Function
 metadata:
   name: function-cue
 spec:
-  package: mitsuwa/function-cue:v0.1.1
+  package: mitsuwa/function-cue:v0.1.2
 ```
 
 ## Debugging

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Ex `cueCompile()` output schema
 	// see docs/READINESS_CHECKS.md for more details
 	readinessChecks?: [...#readinessCheck]
 	// Resource spec
-	base: {
+	resource: {
 		// Example
 		// apiVersion: "nobu.dev/v1"
 		// kind: "Example"
@@ -63,7 +63,7 @@ Ex `cueCompile()` output schema
 ```json
 {
   "name": "my-cluster",
-  "base": {
+  "resource": {
     "apiVersion": "nobu.dev/v1",
     "kind": "XCluster"
   }
@@ -72,15 +72,15 @@ Ex `cueCompile()` output schema
 
 `multiple` - single json document per line, `-e json.MarshalStream(field)` will produce this format
 ```json
-{"name": "my-cluster", "base": {"apiVersion": "nobu.dev/v1", "kind": "XCluster"}}
-{"name": "my-network", "base": {"apiVersion": "nobu.dev/v1", "kind": "XNetwork"}}
+{"name": "my-cluster", "resource": {"apiVersion": "nobu.dev/v1", "kind": "XCluster"}}
+{"name": "my-network", "resource": {"apiVersion": "nobu.dev/v1", "kind": "XNetwork"}}
 ```
 
 #### yaml
 `single`
 ```yaml
 name: "my-cluster"
-base:
+resource:
   apiVersion: "nobu.dev/v1"
   kind: "XCluster"
 ```
@@ -88,12 +88,12 @@ base:
 `multiple` documents, separated by `---`, `-e yaml.MarshalStream(field)` will produce this format
 ```yaml
 name: "my-cluster"
-base:
+resource:
   apiVersion: "nobu.dev/v1"
   kind: "XCluster"
 ---
 name: "my-network"
-base:
+resource:
   apiVersion: "nobu.dev/v1"
   kind: "XNetwork"
 ...

--- a/connection.go
+++ b/connection.go
@@ -94,6 +94,8 @@ func extractConnectionDetails(observed map[resource.Name]resource.ObservedCompos
 							out[conDetail.Name] = b
 						}
 					}
+
+					break
 				}
 			}
 		}
@@ -139,18 +141,10 @@ func validateConnectionDetail(cd connectionDetail) *field.Error {
 			return field.Required(field.NewPath("value"), "value connection detail requires a value")
 		}
 	case connectionDetailTypeFromConnectionSecretKey:
-		if cd.Match.Name == "" || cd.Match.Kind == "" || cd.Match.ApiVersion == "" {
-			return field.Required(field.NewPath("match"), "from connection secret key connection detail requires a gvk+name match")
-		}
-
 		if cd.FromConnectionSecretKey == nil {
 			return field.Required(field.NewPath("fromConnectionSecretKey"), "from connection secret key connection detail requires a key")
 		}
 	case connectionDetailTypeFromFieldPath:
-		if cd.Match.Name == "" || cd.Match.Kind == "" || cd.Match.ApiVersion == "" {
-			return field.Required(field.NewPath("match"), "from connection secret key connection detail requires a gvk+name match")
-		}
-
 		if cd.FromFieldPath == nil {
 			return field.Required(field.NewPath("fromFieldPath"), "from field path connection detail requires a field path")
 		}

--- a/connection.go
+++ b/connection.go
@@ -5,6 +5,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/function-sdk-go/resource"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -54,41 +55,44 @@ type connectionDetail struct {
 
 // extractConnectionDetails extracts XR connection details from the supplied observed map
 // matches against connectionDetails.Match
-func extractConnectionDetails(observed map[resource.Name]resource.ObservedComposed, conDetails []connectionDetail) (managed.ConnectionDetails, error) {
+func extractConnectionDetails(observed map[resource.Name]resource.ObservedComposed, details []cueOutputData) (managed.ConnectionDetails, error) {
 	out := map[string][]byte{}
 
-	for _, detail := range conDetails {
-		if err := validateConnectionDetail(detail); err != nil {
+	for _, detail := range details {
+		conDetail := detail.ConnectioDetail
+
+		if err := validateConnectionDetail(conDetail); err != nil {
 			return nil, err
 		}
 
 		// Setting from value does not require a match
-		if detail.Type == connectionDetailTypeFromValue {
-			out[detail.Name] = []byte(*detail.Value)
+		if conDetail.Type == connectionDetailTypeFromValue {
+			out[conDetail.Name] = []byte(*conDetail.Value)
 			continue
 		}
 
+		u := unstructured.Unstructured{Object: detail.Base}
 		for _, ocd := range observed {
-			if detail.Match.Name == ocd.Resource.GetName() &&
-				detail.Match.Kind == ocd.Resource.GetKind() &&
-				detail.Match.ApiVersion == ocd.Resource.GetAPIVersion() {
+			if u.GetName() == ocd.Resource.GetName() &&
+				u.GetKind() == ocd.Resource.GetKind() &&
+				u.GetAPIVersion() == ocd.Resource.GetAPIVersion() {
 
 				mcd := managed.ConnectionDetails(ocd.ConnectionDetails)
 
-				switch detail.Type {
+				switch conDetail.Type {
 				case connectionDetailTypeFromConnectionSecretKey:
-					if mcd[*detail.FromConnectionSecretKey] == nil {
+					if mcd[*conDetail.FromConnectionSecretKey] == nil {
 						// We don't consider this an error because it's possible the
 						// key will still be written at some point in the future.
 						continue
 					}
-					out[detail.Name] = mcd[*detail.FromConnectionSecretKey]
+					out[conDetail.Name] = mcd[*conDetail.FromConnectionSecretKey]
 				case connectionDetailTypeFromFieldPath:
 					// Note we're checking that the error _is_ nil. If we hit an error
 					// we silently avoid including this connection secret. It's possible
 					// the path will start existing with a valid value in the future.
-					if b, err := fromFieldPath(ocd.Resource, *detail.FromFieldPath); err == nil {
-						out[detail.Name] = b
+					if b, err := fromFieldPath(ocd.Resource, *conDetail.FromFieldPath); err == nil {
+						out[conDetail.Name] = b
 					}
 				}
 			}

--- a/connection.go
+++ b/connection.go
@@ -69,7 +69,6 @@ func extractConnectionDetails(observed map[resource.Name]resource.ObservedCompos
 				continue
 			}
 
-			// u := unstructured.Unstructured{Object: detail.Base}
 			ocd, ok := observed[resource.Name(detail.Name)]
 			if ok {
 				mcd := managed.ConnectionDetails(ocd.ConnectionDetails)

--- a/connection_test.go
+++ b/connection_test.go
@@ -76,7 +76,7 @@ func TestExtractConnectionDetails(t *testing.T) {
 				},
 				details: []cueOutputData{{
 					Name: "test",
-					Base: map[string]interface{}{
+					Resource: map[string]interface{}{
 						"apiVersion": "nobu.dev/v1",
 						"kind":       "test",
 						"metadata": map[string]interface{}{

--- a/connection_test.go
+++ b/connection_test.go
@@ -75,6 +75,7 @@ func TestExtractConnectionDetails(t *testing.T) {
 					},
 				},
 				details: []cueOutputData{{
+					Name: "test",
 					Base: map[string]interface{}{
 						"apiVersion": "nobu.dev/v1",
 						"kind":       "test",

--- a/connection_test.go
+++ b/connection_test.go
@@ -19,7 +19,7 @@ func TestExtractConnectionDetails(t *testing.T) {
 	type args struct {
 		obs     map[rresource.Name]rresource.ObservedComposed
 		data    managed.ConnectionDetails
-		details []connectionDetail
+		details []cueOutputData
 	}
 	type want struct {
 		conn managed.ConnectionDetails
@@ -34,12 +34,14 @@ func TestExtractConnectionDetails(t *testing.T) {
 		"MissingNameError": {
 			reason: "We should return an error if a connection detail is missing a name.",
 			args: args{
-				details: []connectionDetail{
-					{
-						// A nameless connection detail.
-						Type: connectionDetailTypeFromValue,
+				details: []cueOutputData{{
+					ConnectionDetails: []connectionDetail{
+						{
+							// A nameless connection detail.
+							Type: connectionDetailTypeFromValue,
+						},
 					},
-				},
+				}},
 			},
 			want: want{
 				err: &field.Error{
@@ -72,43 +74,37 @@ func TestExtractConnectionDetails(t *testing.T) {
 						},
 					},
 				},
-				details: []connectionDetail{
-					{
-						Match: match{
-							ApiVersion: "nobu.dev/v1",
-							Kind:       "test",
-							Name:       "test",
+				details: []cueOutputData{{
+					Base: map[string]interface{}{
+						"apiVersion": "nobu.dev/v1",
+						"kind":       "test",
+						"metadata": map[string]interface{}{
+							"name": "test",
 						},
-						Type:                    connectionDetailTypeFromConnectionSecretKey,
-						Name:                    "convfoo",
-						FromConnectionSecretKey: pointer.String("foo"),
 					},
-					{
-						Type:  connectionDetailTypeFromValue,
-						Name:  "fixed",
-						Value: pointer.String("value"),
-					},
-					{
-						Match: match{
-							ApiVersion: "nobu.dev/v1",
-							Kind:       "test",
-							Name:       "test",
+					ConnectionDetails: []connectionDetail{
+						{
+							Type:                    connectionDetailTypeFromConnectionSecretKey,
+							Name:                    "convfoo",
+							FromConnectionSecretKey: pointer.String("foo"),
 						},
-						Type:          connectionDetailTypeFromFieldPath,
-						Name:          "name",
-						FromFieldPath: pointer.String("metadata.name"),
-					},
-					{
-						Match: match{
-							ApiVersion: "nobu.dev/v1",
-							Kind:       "test",
-							Name:       "test",
+						{
+							Type:  connectionDetailTypeFromValue,
+							Name:  "fixed",
+							Value: pointer.String("value"),
 						},
-						Type:          connectionDetailTypeFromFieldPath,
-						Name:          "generation",
-						FromFieldPath: pointer.String("metadata.generation"),
+						{
+							Type:          connectionDetailTypeFromFieldPath,
+							Name:          "name",
+							FromFieldPath: pointer.String("metadata.name"),
+						},
+						{
+							Type:          connectionDetailTypeFromFieldPath,
+							Name:          "generation",
+							FromFieldPath: pointer.String("metadata.generation"),
+						},
 					},
-				},
+				}},
 			},
 			want: want{
 				conn: managed.ConnectionDetails{
@@ -120,6 +116,7 @@ func TestExtractConnectionDetails(t *testing.T) {
 			},
 		},
 	}
+
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			conn, err := extractConnectionDetails(tc.args.obs, tc.args.details)

--- a/cue.go
+++ b/cue.go
@@ -416,10 +416,11 @@ func buildExprs(input v1beta1.CUEInput) (exprs []*ast.Expr, err error) {
 		}
 	}
 
-	// If there were no expressions built, add a nil default expression to the front
+	// If there were no expressions built, set exprs to a nil expr set
+	// This implies the cueCompilation will run without any expression
 	if len(exprs) == 0 {
 		// add a nil expression to the beginning
-		exprs = append([]*ast.Expr{nil}, exprs...)
+		exprs = []*ast.Expr{nil}
 	}
 
 	return

--- a/cue.go
+++ b/cue.go
@@ -152,10 +152,10 @@ type cueOutputData struct {
 	Name string `json:"name"`
 	// Base is the managed resource output from the provided cue template
 	Base map[string]interface{} `json:"base,required"`
-	// ConnectionDetail to propagate to the XR
-	ConnectioDetail connectionDetail `json:"connectionDetail,omitempty"`
+	// ConnectionDetails to propagate to the XR
+	ConnectionDetails []connectionDetail `json:"connectionDetail,omitempty"`
 	// ReadinessCheck to propagate to the XR
-	RedinessCheck readinessCheck `json:"readinessCheck,omitempty"`
+	RedinessChecks []readinessCheck `json:"readinessCheck,omitempty"`
 }
 
 // Parse parses the compiled cue template output stored in c.outBuf

--- a/cue.go
+++ b/cue.go
@@ -153,9 +153,9 @@ type cueOutputData struct {
 	// Base is the managed resource output from the provided cue template
 	Base map[string]interface{} `json:"base,required"`
 	// ConnectionDetails to propagate to the XR
-	ConnectionDetails []connectionDetail `json:"connectionDetail,omitempty"`
+	ConnectionDetails []connectionDetail `json:"connectionDetails,omitempty"`
 	// ReadinessCheck to propagate to the XR
-	RedinessChecks []readinessCheck `json:"readinessCheck,omitempty"`
+	RedinessChecks []readinessCheck `json:"readinessChecks,omitempty"`
 }
 
 // Parse parses the compiled cue template output stored in c.outBuf
@@ -281,21 +281,13 @@ func cueCompile(out cueOutputFmt, input v1beta1.CUEInput, opts compileOpts) (com
 	if err != nil {
 		return output, fmt.Errorf("failed building expression(s): %w", err)
 	}
-	if len(exprs) != len(input.Export.Options.Expressions) {
-		return output, fmt.Errorf("number of expressions %d!=%d expressions input", len(exprs), len(input.Export.Options.Expressions))
-	}
 
 	// Run compilation per expression
 	// Output is appended to outputData
 	// Compile string output is added to cmpStr
 	// connection details is output to connectionData
 	for _, expr := range exprs {
-		var (
-			err error
-			c   *compiler
-		)
-
-		c, err = newCompiler(input.Export.Value, inputCUE, out, expr, opts.tags)
+		c, err := newCompiler(input.Export.Value, inputCUE, out, expr, opts.tags)
 		if err != nil {
 			return output, fmt.Errorf("failed creating cue compiler: %w", err)
 		}

--- a/cue.go
+++ b/cue.go
@@ -151,7 +151,7 @@ type cueOutputData struct {
 	// Name is a unique identifier for this entry
 	Name string `json:"name"`
 	// Base is the managed resource output from the provided cue template
-	Base *runtime.RawExtension `json:"base,required"`
+	Base map[string]interface{} `json:"base,required"`
 	// ConnectionDetail to propagate to the XR
 	ConnectioDetail connectionDetail `json:"connectionDetail,omitempty"`
 	// ReadinessCheck to propagate to the XR
@@ -258,17 +258,10 @@ type compileOpts struct {
 	tags      []string
 }
 
-var (
-	errConnectionDetailsNotFound = fmt.Errorf("failed to validate: reference \"#%s\" not found", connectionDetails)
-	errReadinessChecksNotFound   = fmt.Errorf("failed to validate: reference \"#%s\" not found", readinessChecks)
-)
-
 type compileOutput struct {
 	// Data is the parsed output data, excluding configuration expressions
-	data           []cueOutputData
-	connectionData []connectionDetail
-	readinessData  []readinessCheck
-	string         string
+	data   []cueOutputData
+	string string
 }
 
 // cueCompile starting point for cue compilation
@@ -288,15 +281,8 @@ func cueCompile(out cueOutputFmt, input v1beta1.CUEInput, opts compileOpts) (com
 	if err != nil {
 		return output, fmt.Errorf("failed building expression(s): %w", err)
 	}
-	// #connectionDetails expression is always injected into the end of the expression list
-	// #readinessChecks expression is always injected into the end of the expression list
-	if len(exprs) != len(input.Export.Options.Expressions)+len(defaultExprs) {
+	if len(exprs) != len(input.Export.Options.Expressions) {
 		return output, fmt.Errorf("number of expressions %d!=%d expressions input", len(exprs), len(input.Export.Options.Expressions))
-	}
-	// if the only expression in the list is #connectionDetails and #readinessChecks
-	if len(exprs) == len(defaultExprs) {
-		// add a nil expression to the beginning
-		exprs = append([]exprDetail{{expr: nil, exprTarget: document}}, exprs...)
 	}
 
 	// Run compilation per expression
@@ -308,19 +294,9 @@ func cueCompile(out cueOutputFmt, input v1beta1.CUEInput, opts compileOpts) (com
 			err error
 			c   *compiler
 		)
-		if expr.exprTarget != document {
-			// readinessChecks and connectionDetails are always output as Streams
-			out = outputTXT
-		}
 
-		c, err = newCompiler(input.Export.Value, inputCUE, out, expr.expr, opts.tags)
-		if err != nil &&
-			(err.Error() == errConnectionDetailsNotFound.Error() ||
-				err.Error() == errReadinessChecksNotFound.Error()) {
-			// Condition - that there is no #connectionDetails or #readinessChecks expression
-			// If there are no connection details or readiness checks then an empty list is returned
-			continue
-		} else if err != nil {
+		c, err = newCompiler(input.Export.Value, inputCUE, out, expr, opts.tags)
+		if err != nil {
 			return output, fmt.Errorf("failed creating cue compiler: %w", err)
 		}
 		if err = c.Compile(); err != nil {
@@ -334,30 +310,7 @@ func cueCompile(out cueOutputFmt, input v1beta1.CUEInput, opts compileOpts) (com
 				return output, fmt.Errorf("failed parsing cue output: %w", err)
 			}
 
-			// If the expression is a readinessCheck or connectionDetails configuration
-			// Add that data to the specific output
-			if expr.exprTarget != document {
-				// this is a little silly to have to convert this back to a string
-				// maybe there's a better way to do this
-				tmp, err := json.Marshal(data)
-				if err != nil {
-					return output, fmt.Errorf("failed marshalling connection details: %w", err)
-				}
-
-				if expr.exprTarget == connectionDetails {
-					if err := json.Unmarshal(tmp, &output.connectionData); err != nil {
-						return output, fmt.Errorf("failed unmarshalling connection details: %w", err)
-					}
-				} else if expr.exprTarget == readinessChecks {
-					if err := json.Unmarshal(tmp, &output.readinessData); err != nil {
-						return output, fmt.Errorf("failed unmarshalling readiness checks: %w", err)
-					}
-				} else {
-					return output, fmt.Errorf("unknown exprTarget %s", expr.exprTarget)
-				}
-			} else {
-				output.data = append(output.data, data...)
-			}
+			output.data = append(output.data, data...)
 		}
 
 		// If there are multiple yaml documents, then separate them by ---
@@ -455,40 +408,11 @@ func buildTags(tags []v1beta1.Tag, xr *resource.Composite) ([]string, error) {
 	return res, nil
 }
 
-// exprDetail holds configuration for an expression and what its output data parsing should target to
-type exprDetail struct {
-	expr       *ast.Expr
-	exprTarget exprTarget
-}
-
-// exprTarget are the available expression targets to parse the output data to
-type exprTarget string
-
-const (
-	// document target implies the expression is to be parsed for additional or patch document data
-	document exprTarget = "document"
-	// connectionDetails targets the compilation data to store into connectionDetails
-	connectionDetails exprTarget = "connectionDetails"
-	// readienssChecks targets the compilation data to be stored into readinessChecks
-	readinessChecks exprTarget = "readinessChecks"
-)
-
-var (
-	// conDetailsExpr is the string representation of connection details to be passed
-	// From the user to function-cue
-	conDetailsExpr = fmt.Sprintf("json.MarshalStream(#%s)", connectionDetails)
-	// readinessChecksExpr is the string representation of readiness checks to be passed
-	// From the user to function-cue
-	readinessChecksExpr = fmt.Sprintf("json.MarshalStream(#%s)", readinessChecks)
-	// defaultExprs contains a list of default expressions that are always run
-	defaultExprs = []string{conDetailsExpr, readinessChecksExpr}
-)
-
 // buildExprs takes input from the CUEInput and builds cue compatible expressions to be passed to the cue compiler
-func buildExprs(input v1beta1.CUEInput) (exprs []exprDetail, err error) {
+func buildExprs(input v1beta1.CUEInput) (exprs []*ast.Expr, err error) {
 	// #connectionDetails is always added to the end, whether it exists or not
 	// RunFunction will take these details and add them to the XR if found
-	for _, expr := range append(input.Export.Options.Expressions, defaultExprs...) {
+	for _, expr := range input.Export.Options.Expressions {
 		if expr != "" {
 			var parsed ast.Expr
 			parsed, err = parser.ParseExpr("--expression", expr)
@@ -496,15 +420,16 @@ func buildExprs(input v1beta1.CUEInput) (exprs []exprDetail, err error) {
 				err = fmt.Errorf("failed to parse expression: %w", err)
 				return
 			}
-			detail := exprDetail{expr: &parsed, exprTarget: document}
-			if expr == conDetailsExpr {
-				detail.exprTarget = connectionDetails
-			} else if expr == readinessChecksExpr {
-				detail.exprTarget = readinessChecks
-			}
-			exprs = append(exprs, detail)
+			exprs = append(exprs, &parsed)
 		}
 	}
+
+	// If there were no expressions built, add a nil default expression to the front
+	if len(exprs) == 0 {
+		// add a nil expression to the beginning
+		exprs = append([]*ast.Expr{nil}, exprs...)
+	}
+
 	return
 }
 

--- a/cue.go
+++ b/cue.go
@@ -150,8 +150,8 @@ func (c compiler) Bytes() []byte {
 type cueOutputData struct {
 	// Name is a unique identifier for this entry
 	Name string `json:"name"`
-	// Base is the managed resource output from the provided cue template
-	Base map[string]interface{} `json:"base,required"`
+	// Resource is the managed resource output from the provided cue template
+	Resource map[string]interface{} `json:"resource,required"`
 	// ConnectionDetails to propagate to the XR
 	ConnectionDetails []connectionDetail `json:"connectionDetails,omitempty"`
 	// ReadinessCheck to propagate to the XR

--- a/docs/CONNECTION_DETAILS.md
+++ b/docs/CONNECTION_DETAILS.md
@@ -5,23 +5,13 @@ into the xr
 
 #### Enabling
 
-The connection details must be defined in the cue template `#connectionDetails`
+The connection details are defined in the cue template, per document's, `connectionDetails?: [...#connectionDetail]`
 
 ```cue
 // Following the Schema
 #connectionDetailType: "FromConnectionSecretKey" | "FromFieldPath" | "FromValue"
 
-#match: {
-	apiVersion: string
-	kind:       string
-	name:       string
-}
-
 #connectionDetail: {
-    // Used for FromConnectionSecretKey and FromFieldPath to match the
-    // ObservedComposed Resource to pull the values from
-	Match?: #match
-
 	// Name of the connection secret key that will be propagated to the
 	// connection secret of the composed resource.
 	Name: string
@@ -45,27 +35,7 @@ The connection details must be defined in the cue template `#connectionDetails`
 	// value, for example a well-known port.
 	Value?: string
 }
-
-#connectionDetails: [...#connectionDetail] & [
-    // insert details here
-]
 ```
 
 This data will be evaluated by function-cue and the values will be propagated to the xr.
 If there are no details found, then the xr will not receive any propagation
-
-#### TODO
-
-allow for individual `#connectionDetail` to be specified within each document. This
-would allow the match association to not need to be specified twice
-
-This can be achieved by either, with either, on the instance
-
-no expression:
-
-- add additional expression for `#connectionDetail`, to check if there is a single connectionDetail
-  within the document
-- if there is any amount of nonstream expressions, take those expressions and also add an
-  another with the origianl `$expr.#connectionDetail` etc..
-- if there is a stream expression, add the additional expression to get the connection details
-  per stream `yaml.MarshalStream(list.FlattenN([for e in output {e.#connectionDetails}], 2))`

--- a/docs/GOALS.md
+++ b/docs/GOALS.md
@@ -5,7 +5,6 @@
 
 ### TODO
 
-1. Support selection matching based on `resource.Name`
 1. Support importing non stdlib packages
 1. All of the `cue export` optional args to be implemented - see [EXPORT_OPTIONS.md](EXPORT_OPTIONS.md)
 1. Add support for loading cue files from configmap

--- a/docs/GOALS.md
+++ b/docs/GOALS.md
@@ -11,8 +11,6 @@
    1. For example, identifiers can be stored in configmaps for managed resources
 1. Add support for crossplane Environments to be _"injected"_ into `cue export`
 1. Support label selectors for Patch matching
-   1. Because of the way gvk+name is used for selection, this means you cannot overwrite these fields
-      adding support for label selection or desired composed name selection will allow for this overwriting as well
 1. `go:generate` support to generate schema and identifiers, stored in configMaps, for `MRs` schema's from `provider-aws` `provider-gcp` and `provider-azure`
    1. configMap support + generation of MR schema will allow for crossplane administrators
       to combine these functionalities with `xrender`, which can solve schema verification on MRs

--- a/docs/MERGING_VALUES.md
+++ b/docs/MERGING_VALUES.md
@@ -39,11 +39,11 @@ Fields are set on the XR directly, overwriting existing fields
 
 #### `PatchResources` DesiredComposed
 
-Fields are set on the existing `CUEInput.Resources`, overwriting existing fields.  The existing resource is selected based on the apiVersion+kind+name
+Fields are set on the existing `CUEInput.Resources`, overwriting existing fields.  The existing resource is selected based on the name
 
 #### `PatchDesired` DesiredComposed
 
-Fields are set on the existing resource, overwriting existing fields.  The existing resource is selected based on the apiVersion+kind+name
+Fields are set on the existing resource, overwriting existing fields.  The existing resource is selected based on the name
 
 ### overwrite:false implementation
 

--- a/docs/READINESS_CHECKS.md
+++ b/docs/READINESS_CHECKS.md
@@ -5,7 +5,7 @@ into the xr
 
 #### Enabling
 
-The readiness checks must be defined in the cue template `#readinessChecks`
+The readiness checks are defined in the cue template, per document's, `readinessChecks?: [...#readinessCheck]`
 
 ```cue
 // Following the schema
@@ -19,16 +19,7 @@ The readiness checks must be defined in the cue template `#readinessChecks`
         Status: "True" | "False" | "Unknown"
 }
 
-#match: {
-        apiVersion: string
-        kind:       string
-        name:       string
-}
-
 #readinessCheck: {
-        // Used to match the ObservedComposed Resource to pull the values from
-        Match: #match
-
         // Type indicates the type of probe to use.
         Type: "MatchCondition" | "MatchEmpty" | "MatchInteger" | "MatchString" | "MatchTrue" | "MatchFalse" | "None"
 
@@ -44,27 +35,7 @@ The readiness checks must be defined in the cue template `#readinessChecks`
         // MatchCondition specifies the condition you'd like to match if you're using "MatchCondition" type.
         MatchCondition?: #matchConditionReadinessCheck
 }
-
-#readinessChecks: [...#readinessCheck] & [
-    // insert details here
-]
 ```
 
 This data will be evaluated by function-cue and the values will be propagated to the xr.
 If there are no details found, then the xr will not receive any propagation
-
-#### TODO
-
-allow for individual `#readinessChecks` to be specified within each document. This
-would allow the match association to not need to be specified twice
-
-This can be achieved by either, with either, on the instance
-
-no expression:
-
-- add additional expression for `#readinessCheck`, to check if there is a single connectionDetail
-  within the document
-- if there is any amount of nonstream expressions, take those expressions and also add an
-  another with the origianl `$expr.#readinessCheck` etc..
-- if there is a stream expression, add the additional expression to get the connection details
-  per stream `yaml.MarshalStream(list.FlattenN([for e in $expr {e.#readinessCheck}], 2))`

--- a/examples/functions.yaml
+++ b/examples/functions.yaml
@@ -3,4 +3,4 @@ kind: Function
 metadata:
   name: function-cue
 spec:
-  package: mitsuwa/function-cue:v0.1.0
+  package: mitsuwa/function-cue:v0.1.2

--- a/examples/patch_desired/patching/composition.yaml
+++ b/examples/patch_desired/patching/composition.yaml
@@ -24,18 +24,23 @@ spec:
         value: |
           output: [
             {
-              apiVersion: "s3.aws.upbound.io/v1beta1"
-              kind: "Bucket"
-              metadata: name: "test-bucket"
-              spec: forProvider: region: "us-east-2"
+              name: "test-bucket"
+              base: {
+                apiVersion: "s3.aws.upbound.io/v1beta1"
+                kind: "Bucket"
+                spec: forProvider: region: "us-east-2"
+              }
             },
             {
-              apiVersion: "ec2.aws.upbound.io/v1beta1"
-              kind: "Instance"
-              metadata: name: "someinstance"
-              spec: forProvider: ami: "ami-0d9858aa3c6322f73"
-              spec: forProvider: instanceType: "t2.micro"
-              spec: forProvider: region: "us-east-2"
+              name: "someinstance"
+              base: {
+                apiVersion: "ec2.aws.upbound.io/v1beta1"
+                kind: "Instance"
+                metadata: name: "someinstance"
+                spec: forProvider: ami: "ami-0d9858aa3c6322f73"
+                spec: forProvider: instanceType: "t2.micro"
+                spec: forProvider: region: "us-east-2"
+              }
             }
           ]
   - step: patch-storage-bucket

--- a/examples/patch_desired/patching/composition.yaml
+++ b/examples/patch_desired/patching/composition.yaml
@@ -54,7 +54,8 @@ spec:
         target: PatchDesired
         value: |
           // Target the bucket by name
-          name: "test-bucket"
+          // Multiple Objects are prefixed by the CUEInput.name-
+          name: "prime-objects-test-bucket"
           base: {
             // Add fields here
             metadata: annotations: {

--- a/examples/patch_desired/patching/composition.yaml
+++ b/examples/patch_desired/patching/composition.yaml
@@ -25,7 +25,7 @@ spec:
           output: [
             {
               name: "test-bucket"
-              base: {
+              resource: {
                 apiVersion: "s3.aws.upbound.io/v1beta1"
                 kind: "Bucket"
                 spec: forProvider: region: "us-east-2"
@@ -33,7 +33,7 @@ spec:
             },
             {
               name: "someinstance"
-              base: {
+              resource: {
                 apiVersion: "ec2.aws.upbound.io/v1beta1"
                 kind: "Instance"
                 spec: forProvider: ami: "ami-0d9858aa3c6322f73"
@@ -56,7 +56,7 @@ spec:
           // Target the bucket by name
           // Multiple Objects are prefixed by the CUEInput.name-
           name: "prime-objects-test-bucket"
-          base: {
+          resource: {
             // Add fields here
             metadata: annotations: {
                 "nobu.dev/cueified": "true",

--- a/examples/patch_desired/patching/composition.yaml
+++ b/examples/patch_desired/patching/composition.yaml
@@ -36,7 +36,6 @@ spec:
               base: {
                 apiVersion: "ec2.aws.upbound.io/v1beta1"
                 kind: "Instance"
-                metadata: name: "someinstance"
                 spec: forProvider: ami: "ami-0d9858aa3c6322f73"
                 spec: forProvider: instanceType: "t2.micro"
                 spec: forProvider: region: "us-east-2"
@@ -54,15 +53,14 @@ spec:
       export:
         target: PatchDesired
         value: |
-          // Target the bucket by apiVersion+kind+name
-          apiVersion: "s3.aws.upbound.io/v1beta1"
-          kind: "Bucket"
-          metadata: name: "test-bucket"
-          
-          // Add fields here
-          metadata: annotations: {
-              "nobu.dev/cueified": "true",
-              "nobu.dev/app": "someapp",
+          // Target the bucket by name
+          name: "test-bucket"
+          base: {
+            // Add fields here
+            metadata: annotations: {
+                "nobu.dev/cueified": "true",
+                "nobu.dev/app": "someapp",
+            }
+            
+            spec: forProvider: policy: "some-bucket-policy"
           }
-          
-          spec: forProvider: policy: "some-bucket-policy"

--- a/examples/patch_resources/patching/composition.yaml
+++ b/examples/patch_resources/patching/composition.yaml
@@ -20,7 +20,7 @@ spec:
         target: PatchResources
         resources:
         - name: bucket
-          base:
+          resource:
             apiVersion: nobu.dev/v1
             kind: Bucket
             metadata:
@@ -28,7 +28,7 @@ spec:
         value: |
           // Target the bucket by name
           name: "bucket"
-          base: {
+          resource: {
             // Add fields here
             metadata: annotations: {
                 "nobu.dev/cueified": "true",

--- a/examples/patch_resources/patching/composition.yaml
+++ b/examples/patch_resources/patching/composition.yaml
@@ -26,15 +26,14 @@ spec:
             metadata:
               name: test-bucket
         value: |
-          // Target the bucket by apiVersion+kind+name
-          apiVersion: "nobu.dev/v1"
-          kind: "Bucket"
-          metadata: name: "test-bucket"
-          
-          // Add fields here
-          metadata: annotations: {
-              "nobu.dev/cueified": "true",
-              "nobu.dev/app": "someapp",
+          // Target the bucket by name
+          name: "bucket"
+          base: {
+            // Add fields here
+            metadata: annotations: {
+                "nobu.dev/cueified": "true",
+                "nobu.dev/app": "someapp",
+            }
+            
+            spec: forProvider: policy: "some-bucket-policy"
           }
-          
-          spec: forProvider: policy: "some-bucket-policy"

--- a/examples/patch_resources/patching_multiple/composition.yaml
+++ b/examples/patch_resources/patching_multiple/composition.yaml
@@ -45,7 +45,7 @@ spec:
             {
               // Target the bucket by name
               name: "bucket"
-              base: {
+              resource: {
                 metadata: annotations: {
                     "nobu.dev/cueified": "true",
                     "nobu.dev/app": "someapp",
@@ -57,7 +57,7 @@ spec:
             {
               // Target the user by name
               name: "iam-user"
-              base: {
+              resource: {
                 metadata: annotations: {
                     "nobu.dev/cueified": "true",
                     "nobu.dev/app": "someapp",
@@ -69,7 +69,7 @@ spec:
             {
               // Target the bucket by name
               name: "iam-role"
-              base: {
+              resource: {
                 metadata: annotations: {
                     "nobu.dev/cueified": "true",
                     "nobu.dev/app": "someapp",

--- a/examples/patch_resources/patching_multiple/composition.yaml
+++ b/examples/patch_resources/patching_multiple/composition.yaml
@@ -43,45 +43,39 @@ spec:
         value: |
           output: [ 
             {
-              // Target the bucket by apiVersion+kind+name
-              apiVersion: "nobu.dev/v1"
-              kind: "Bucket"
-              metadata: name: "test-bucket"
-              
-              // Add fields here
-              metadata: annotations: {
-                  "nobu.dev/cueified": "true",
-                  "nobu.dev/app": "someapp",
+              // Target the bucket by name
+              name: "bucket"
+              base: {
+                metadata: annotations: {
+                    "nobu.dev/cueified": "true",
+                    "nobu.dev/app": "someapp",
+                }
+                
+                spec: forProvider: policy: "some-bucket-policy"
               }
-              
-              spec: forProvider: policy: "some-bucket-policy"
             }, 
             {
-              // Target the user by apiVersion+kind+name
-              apiVersion: "nobu.dev/v1"
-              kind: "User"
-              metadata: name: "test-user"
-              
-              // Add fields here
-              metadata: annotations: {
-                  "nobu.dev/cueified": "true",
-                  "nobu.dev/app": "someapp",
-              }
+              // Target the user by name
+              name: "iam-user"
+              base: {
+                metadata: annotations: {
+                    "nobu.dev/cueified": "true",
+                    "nobu.dev/app": "someapp",
+                }
 
-              spec: forProvider: name: "somename"
+                spec: forProvider: name: "somename"
+              }
             }, 
             {
-              // Target the bucket by apiVersion+kind+name
-              apiVersion: "nobu.dev/v1"
-              kind: "Role"
-              metadata: name: "test-role"
-              
-              // Add fields here
-              metadata: annotations: {
-                  "nobu.dev/cueified": "true",
-                  "nobu.dev/app": "someapp",
+              // Target the bucket by name
+              name: "iam-role"
+              base: {
+                metadata: annotations: {
+                    "nobu.dev/cueified": "true",
+                    "nobu.dev/app": "someapp",
+                }
+                
+                spec: forProvider: policy: "some-role-policy"
               }
-              
-              spec: forProvider: policy: "some-role-policy"
             },
           ]

--- a/examples/resources/README.md
+++ b/examples/resources/README.md
@@ -2,8 +2,4 @@
 
 The `CUEInput` export `Resources` target is utilized to specify **New** resources to be created.
 
-The documents generated must have an `apiVersion`, `kind` and `name` associated to them.
-
-## TODO
-
-- If a resource's (to be created) gvk+name match a resource from the cue generation - return error
+The documents generated must have an `apiVersion` and `kind` associated to them.

--- a/examples/resources/conditionals/composition.yaml
+++ b/examples/resources/conditionals/composition.yaml
@@ -24,7 +24,7 @@ spec:
           }
           
           name: "TestNodepool"
-          base: {
+          resource: {
             if #ENV["PROVIDER"] == "aws" {
             	apiVersion: "eks.nobu.dev/v1beta"
             }

--- a/examples/resources/conditionals/composition.yaml
+++ b/examples/resources/conditionals/composition.yaml
@@ -23,23 +23,26 @@ spec:
           	PROVIDER: "aws"
           }
           
-          if #ENV["PROVIDER"] == "aws" {
-          	apiVersion: "eks.nobu.dev/v1beta"
-          }
-          if #ENV["PROVIDER"] == "gcp" {
-          	apiVersion: "gke.nobu.dev/v1beta1"
-          }
-          
-          kind: "XNodepool"
-          metadata: name: "TestNodepool"
-          spec: parameters: {
-          	autoscaling: [{
-          		maxNodeCount: 1
-          		minNodeCount: 1
-          	}]
-          	clusterName: "example1"
-          	if #ENV["LABELS"] != _|_ {
-          		nodeLabels: #ENV["LABELS"]
-          	}
-          	region: "us-east-2"
+          name: "TestNodepool"
+          base: {
+            if #ENV["PROVIDER"] == "aws" {
+            	apiVersion: "eks.nobu.dev/v1beta"
+            }
+            if #ENV["PROVIDER"] == "gcp" {
+            	apiVersion: "gke.nobu.dev/v1beta1"
+            }
+            
+            kind: "XNodepool"
+            spec: parameters: {
+            	autoscaling: [{
+            		maxNodeCount: 1
+            		minNodeCount: 1
+            	}]
+            	clusterName: "example1"
+                // _|_ checks for existence
+            	if #ENV["LABELS"] != _|_ {
+            		nodeLabels: #ENV["LABELS"]
+            	}
+            	region: "us-east-2"
+            }
           }

--- a/examples/resources/identifiers/composition.yaml
+++ b/examples/resources/identifiers/composition.yaml
@@ -24,7 +24,7 @@ spec:
         value: |
           #identification: [ID=_]: {
             name: ID
-            base: {
+            resource: {
               apiVersion: "nobu.dev/v1"
               kind:       "XCluster"
               spec: {
@@ -47,6 +47,6 @@ spec:
             }
           }
           
-          #identification: cluster: base: spec: forProvider: {
+          #identification: cluster: resource: spec: forProvider: {
           	network: "somenetwork"
           }

--- a/examples/resources/identifiers/composition.yaml
+++ b/examples/resources/identifiers/composition.yaml
@@ -47,6 +47,6 @@ spec:
             }
           }
           
-          #identification: cluster: spec: forProvider: {
+          #identification: cluster: base: spec: forProvider: {
           	network: "somenetwork"
           }

--- a/examples/resources/identifiers/composition.yaml
+++ b/examples/resources/identifiers/composition.yaml
@@ -23,26 +23,28 @@ spec:
           - "#identification.cluster"
         value: |
           #identification: [ID=_]: {
-          	apiVersion: "nobu.dev/v1"
-          	kind:       "XCluster"
-          	metadata: name: ID
-          	spec: {
-          		forProvider: {
-          			network: string
-          			masterAuthorizedNetworksConfig: {
-          				cidrBlocks: [
-          					{
-          						cidrBlock: "10.0.0.0/18"
-          						name:      "somevpc"
-          					},
-          					{
-          						cidrBlock: "1.0.0.0/32"
-          						name:      "vpn"
-          					},
-          				]
-          			}
-          		}
-          	}
+            name: ID
+            base: {
+              apiVersion: "nobu.dev/v1"
+              kind:       "XCluster"
+              spec: {
+              	forProvider: {
+              		network: string
+              		masterAuthorizedNetworksConfig: {
+              			cidrBlocks: [
+              				{
+              					cidrBlock: "10.0.0.0/18"
+              					name:      "somevpc"
+              				},
+              				{
+              					cidrBlock: "1.0.0.0/32"
+              					name:      "vpn"
+              				},
+              			]
+              		}
+              	}
+              }
+            }
           }
           
           #identification: cluster: spec: forProvider: {

--- a/examples/resources/injections/composition.yaml
+++ b/examples/resources/injections/composition.yaml
@@ -25,20 +25,22 @@ spec:
         value: |
           #env: string @tag("provider")
           
-          if #env == "aws" {
-          	apiVersion: "eks.nobu.dev/v1beta"
-          }
-          if #env == "gcp" {
-          	apiVersion: "gke.nobu.dev/v1beta1"
-          }
-          
-          kind: "XNodepool"
-          metadata: name: "TestNodepool"
-          spec: parameters: {
-          	autoscaling: [{
-          		maxNodeCount: 1
-          		minNodeCount: 1
-          	}]
-          	clusterName: "example-injections"
-          	region: "us-east-2"
+          name: "TestNodepool"
+          base: {
+            if #env == "aws" {
+            	apiVersion: "eks.nobu.dev/v1beta"
+            }
+            if #env == "gcp" {
+            	apiVersion: "gke.nobu.dev/v1beta1"
+            }
+            
+            kind: "XNodepool"
+            spec: parameters: {
+            	autoscaling: [{
+            		maxNodeCount: 1
+            		minNodeCount: 1
+            	}]
+            	clusterName: "example-injections"
+            	region: "us-east-2"
+            }
           }

--- a/examples/resources/injections/composition.yaml
+++ b/examples/resources/injections/composition.yaml
@@ -26,7 +26,7 @@ spec:
           #env: string @tag("provider")
           
           name: "TestNodepool"
-          base: {
+          resource: {
             if #env == "aws" {
             	apiVersion: "eks.nobu.dev/v1beta"
             }

--- a/examples/resources/multipleresources/composition.yaml
+++ b/examples/resources/multipleresources/composition.yaml
@@ -24,28 +24,38 @@ spec:
         value: |
           output: [
           	{
-          		apiVersion: "nobu.dev/v1"
-          		kind:       "Cluster"
-          		metadata: name: "example-cluster"
+                name: "example-cluster"
+                base: {
+          	  	  apiVersion: "nobu.dev/v1"
+            	  kind:       "Cluster"
+                }
           	},
           	{
-          		apiVersion: "nobu.dev/v1"
-          		kind:       "Network"
-          		metadata: name: "example-network"
+                name: "example-network"
+                base: {
+          		  apiVersion: "nobu.dev/v1"
+          	  	  kind:       "Network"
+                }
           	},
           	{
-          		apiVersion: "nobu.dev/v1"
-          		kind:       "Memorystore"
-          		metadata: name: "example-memorystore"
+                name: "example-memorystore"
+                base: {
+          		  apiVersion: "nobu.dev/v1"
+          		  kind:       "Memorystore"
+                }
           	},
           	{
-          		apiVersion: "nobu.dev/v1"
-          		kind:       "Firewalls"
-          		metadata: name: "example-firewalls"
+                name: "example-firewalls"
+                base: {
+          	  	  apiVersion: "nobu.dev/v1"
+            	  kind:       "Firewalls"
+                }
           	},
           	{
-          		apiVersion: "nobu.dev/v1"
-          		kind:       "Nodepool"
-          		metadata: name: "example-nodepools"
+                name: "example-nodepools"
+                base: {
+          		  apiVersion: "nobu.dev/v1"
+          		  kind:       "Nodepool"
+                }
           	},
           ]

--- a/examples/resources/multipleresources/composition.yaml
+++ b/examples/resources/multipleresources/composition.yaml
@@ -25,35 +25,35 @@ spec:
           output: [
           	{
                 name: "example-cluster"
-                base: {
+                resource: {
           	  	  apiVersion: "nobu.dev/v1"
             	  kind:       "Cluster"
                 }
           	},
           	{
                 name: "example-network"
-                base: {
+                resource: {
           		  apiVersion: "nobu.dev/v1"
           	  	  kind:       "Network"
                 }
           	},
           	{
                 name: "example-memorystore"
-                base: {
+                resource: {
           		  apiVersion: "nobu.dev/v1"
           		  kind:       "Memorystore"
                 }
           	},
           	{
                 name: "example-firewalls"
-                base: {
+                resource: {
           	  	  apiVersion: "nobu.dev/v1"
             	  kind:       "Firewalls"
                 }
           	},
           	{
                 name: "example-nodepools"
-                base: {
+                resource: {
           		  apiVersion: "nobu.dev/v1"
           		  kind:       "Nodepool"
                 }

--- a/examples/xr/README.md
+++ b/examples/xr/README.md
@@ -2,8 +2,4 @@
 
 The `CUEInput` export `XR` target is utilized to patch the Desired `XR`
 
-There is no gvk+name matching on XR patching
-
-### TODO
-
-Merging annotations and labels
+There is no name matching on XR patching

--- a/examples/xr/patching/composition.yaml
+++ b/examples/xr/patching/composition.yaml
@@ -19,9 +19,12 @@ spec:
       export:
         target: XR
         value: |
-          metadata: annotations: {
-              "nobu.dev/cueified": "true",
-              "nobu.dev/app": "someapp",
+          name: "XRPatching"
+          base: {
+            metadata: annotations: {
+                "nobu.dev/cueified": "true",
+                "nobu.dev/app": "someapp",
+            }
+            
+            spec: forProvider: network: "somenetwork"
           }
-          
-          spec: forProvider: network: "somenetwork"

--- a/examples/xr/patching/composition.yaml
+++ b/examples/xr/patching/composition.yaml
@@ -20,7 +20,7 @@ spec:
         target: XR
         value: |
           name: "XRPatching"
-          base: {
+          resource: {
             metadata: annotations: {
                 "nobu.dev/cueified": "true",
                 "nobu.dev/app": "someapp",

--- a/fn.go
+++ b/fn.go
@@ -283,9 +283,9 @@ func matchResources(desired map[resource.Name]*resource.DesiredComposed, data []
 		// PatchDesired
 		if found, ok := desired[resource.Name(d.Name)]; ok {
 			if _, ok := matches[found]; !ok {
-				matches[found] = []map[string]interface{}{d.Base}
+				matches[found] = []map[string]interface{}{d.Resource}
 			} else {
-				matches[found] = append(matches[found], d.Base)
+				matches[found] = append(matches[found], d.Resource)
 			}
 			count++
 		}
@@ -312,7 +312,7 @@ func (output *successOutput) setSuccessMsgs() {
 		desired := output.object.([]cueOutputData)
 		j := 0
 		for _, d := range desired {
-			u := unstructured.Unstructured{Object: d.Base}
+			u := unstructured.Unstructured{Object: d.Resource}
 			output.msgs[j] = fmt.Sprintf("created resource \"%s:%s\"", u.GetName(), u.GetKind())
 			j++
 		}
@@ -320,7 +320,7 @@ func (output *successOutput) setSuccessMsgs() {
 		desired := output.object.([]cueOutputData)
 		j := 0
 		for _, d := range desired {
-			u := unstructured.Unstructured{Object: d.Base}
+			u := unstructured.Unstructured{Object: d.Resource}
 			output.msgs[j] = fmt.Sprintf("updated resource \"%s:%s\"", u.GetName(), u.GetKind())
 			j++
 		}
@@ -328,7 +328,7 @@ func (output *successOutput) setSuccessMsgs() {
 		desired := output.object.([]cueOutputData)
 		j := 0
 		for _, d := range desired {
-			u := unstructured.Unstructured{Object: d.Base}
+			u := unstructured.Unstructured{Object: d.Resource}
 			output.msgs[j] = fmt.Sprintf("created resource \"%s:%s\"", u.GetName(), u.GetKind())
 			j++
 		}
@@ -372,7 +372,7 @@ func addResourcesTo(o any, conf addResourcesConf) error {
 		for _, d := range conf.data {
 			name := resource.Name(d.Name)
 			u := unstructured.Unstructured{
-				Object: d.Base,
+				Object: d.Resource,
 			}
 
 			// Add the resource name as a suffix to the basename
@@ -382,7 +382,7 @@ func addResourcesTo(o any, conf addResourcesConf) error {
 			}
 			// If the value exists, merge its existing value with the patches
 			if v, ok := desired[name]; ok {
-				mergedData := merged(d.Base, v)
+				mergedData := merged(d.Resource, v)
 				u = unstructured.Unstructured{Object: mergedData}
 			}
 			desired[name] = &resource.DesiredComposed{
@@ -406,7 +406,7 @@ func addResourcesTo(o any, conf addResourcesConf) error {
 	case *resource.Composite:
 		// XR
 		for _, d := range conf.data {
-			if err := setData(d.Base, "", o, conf.overwrite); err != nil {
+			if err := setData(d.Resource, "", o, conf.overwrite); err != nil {
 				return errors.Wrap(err, "cannot set data on xr")
 			}
 		}

--- a/fn.go
+++ b/fn.go
@@ -464,7 +464,7 @@ func setData(data any, path string, o any, overwrite bool) error {
 		case *resource.DesiredComposed:
 			path = strings.TrimPrefix(path, ".")
 
-			// Because we match on gvk+name, there is no need to set this
+			// Currently do not allow overwriting apiVersion kind or name
 			// ignore setting these again because this will conflict with the overwrite settings
 			if path == "apiVersion" || path == "kind" || path == "metadata.name" {
 				return nil

--- a/fn_test.go
+++ b/fn_test.go
@@ -1599,7 +1599,7 @@ func TestRunFunction(t *testing.T) {
 							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR"}`),
 						},
 						Resources: map[string]*fnv1beta1.Resource{
-							"observe-connections": {
+							"example-cluster": {
 								Resource: resource.MustStructJSON(`{
 									"apiVersion": "nobu.dev/v1",
 									"kind": "findme",

--- a/fn_test.go
+++ b/fn_test.go
@@ -47,7 +47,7 @@ func TestRunFunction(t *testing.T) {
 						},
 						"export": {
 							"target": "Resources",
-							"value": "name: \"basic\"\nbase: {\n\tapiVersion: \"example.org/v1\"\n\tkind:       \"Generated\"\n}\n"
+							"value": "name: \"basic\"\nresource: {\n\tapiVersion: \"example.org/v1\"\n\tkind:       \"Generated\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -91,7 +91,7 @@ func TestRunFunction(t *testing.T) {
 						},
 						"export": {
 							"target": "Resources",
-							"value": " let #ENV = {\n\tPROVIDER: \"aws\"\n}\n\nname: \"conditional\"\nbase: {\n\tif #ENV[\"PROVIDER\"] == \"aws\" {\n\t\tapiVersion: \"eks.nobu.dev/v1beta\"\n\t}\n\tif #ENV[\"PROVIDER\"] == \"gcp\" {\n\t\tapiVersion: \"gke.nobu.dev/v1beta1\"\n\t}\n\n\tkind: \"XNodepool\"\n\tspec: parameters: {\n\t\tautoscaling: [{\n\t\t\tmaxNodeCount: 1\n\t\t\tminNodeCount: 1\n\t\t}]\n\t\tclusterName: \"example1\"\n\t\tif #ENV[\"LABELS\"] != _|_ {\n\t\t\tnodeLabels: #ENV[\"LABELS\"]\n\t\t}\n\t\tregion: \"us-east-2\"\n\t}\n}\n"
+							"value": " let #ENV = {\n\tPROVIDER: \"aws\"\n}\n\nname: \"conditional\"\nresource: {\n\tif #ENV[\"PROVIDER\"] == \"aws\" {\n\t\tapiVersion: \"eks.nobu.dev/v1beta\"\n\t}\n\tif #ENV[\"PROVIDER\"] == \"gcp\" {\n\t\tapiVersion: \"gke.nobu.dev/v1beta1\"\n\t}\n\n\tkind: \"XNodepool\"\n\tspec: parameters: {\n\t\tautoscaling: [{\n\t\t\tmaxNodeCount: 1\n\t\t\tminNodeCount: 1\n\t\t}]\n\t\tclusterName: \"example1\"\n\t\tif #ENV[\"LABELS\"] != _|_ {\n\t\t\tnodeLabels: #ENV[\"LABELS\"]\n\t\t}\n\t\tregion: \"us-east-2\"\n\t}\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -150,7 +150,7 @@ func TestRunFunction(t *testing.T) {
 						},
 						"export": {
 							"target": "Resources",
-							"value": "#deployment: [ID=_]: {\n\tapiVersion: \"apps/v1\"\n\tkind:       \"Deployment\"\n\tmetadata: name: ID\n\tspec: {\n\t\treplicas: *1 | int\n\t\ttemplate: {\n\t\t\tmetadata: labels: {\n\t\t\t\tapp:       ID\n\t\t\t\tdomain:    \"prod\"\n\t\t\t\tcomponent: string\n\t\t\t}\n\t\t\tspec: containers: [{name: ID}]\n\t\t}\n\t}\n}\n\n#deployment: echoserver: spec: template: {\n\tmetadata: annotations: {\n\t\t\"prometheus.io.scrape\": \"true\"\n\t\t\"prometheus.io.port\":   \"7080\"\n\t}\n\tmetadata: labels: {\n\t\t\"component\": \"core\"\n\t}\n}\n\nname: \"identifier\"\nbase: #deployment.echoserver\n"
+							"value": "#deployment: [ID=_]: {\n\tapiVersion: \"apps/v1\"\n\tkind:       \"Deployment\"\n\tmetadata: name: ID\n\tspec: {\n\t\treplicas: *1 | int\n\t\ttemplate: {\n\t\t\tmetadata: labels: {\n\t\t\t\tapp:       ID\n\t\t\t\tdomain:    \"prod\"\n\t\t\t\tcomponent: string\n\t\t\t}\n\t\t\tspec: containers: [{name: ID}]\n\t\t}\n\t}\n}\n\n#deployment: echoserver: spec: template: {\n\tmetadata: annotations: {\n\t\t\"prometheus.io.scrape\": \"true\"\n\t\t\"prometheus.io.port\":   \"7080\"\n\t}\n\tmetadata: labels: {\n\t\t\"component\": \"core\"\n\t}\n}\n\nname: \"identifier\"\nresource: #deployment.echoserver\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -229,7 +229,7 @@ func TestRunFunction(t *testing.T) {
 								]
 							},
 							"target": "Resources",
-							"value": "output: [\n\t{\n\t\tname: \"example-cluster\"\n\t\tbase: {\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Cluster\"\n\t\t}\n\t},\n\t{\n\t\tname: \"example-nodepool\"\n\t\tbase: {\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Nodepool\"\n\t\t}\n\t},\n]\n"
+							"value": "output: [\n\t{\n\t\tname: \"example-cluster\"\n\t\tresource: {\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Cluster\"\n\t\t}\n\t},\n\t{\n\t\tname: \"example-nodepool\"\n\t\tresource: {\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Nodepool\"\n\t\t}\n\t},\n]\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -291,7 +291,7 @@ func TestRunFunction(t *testing.T) {
 								]
 							},
 							"target": "Resources",
-							"value": "output: [\n\t{\n\t\tname: \"example-cluster\"\n\t\tbase: {\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Cluster\"\n\t\t}\n\t},\n\t{\n\t\tname: \"example-nodepool\"\n\t\tbase: {\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Nodepool\"\n\t\t}\n\t},\n]\n"
+							"value": "output: [\n\t{\n\t\tname: \"example-cluster\"\n\t\tresource: {\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Cluster\"\n\t\t}\n\t},\n\t{\n\t\tname: \"example-nodepool\"\n\t\tresource: {\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Nodepool\"\n\t\t}\n\t},\n]\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -355,7 +355,7 @@ func TestRunFunction(t *testing.T) {
 								]
 							},
 							"target": "Resources",
-							"value": "cluster: {\n\tname: \"example-cluster\"\n\tbase: {\n\t\tapiVersion: \"nobu.dev/v1\"\n\t\tkind:       \"Cluster\"\n\t\tmetadata: name: \"example-cluster\"\n\t}\n}\nnodepool: {\n\tname: \"example-nodepool\"\n\tbase: {\n\t\tapiVersion: \"nobu.dev/v1\"\n\t\tkind:       \"Nodepool\"\n\t\tmetadata: name: \"example-nodepool\"\n\t}\n}\nvpc: {\n\tname: \"example-vpc\"\n\tbase: {\n\t\tapiVersion: \"nobu.dev/v1\"\n\t\tkind:       \"Vpc\"\n\t\tmetadata: name: \"example-vpc\"\n\t}\n}\n"
+							"value": "cluster: {\n\tname: \"example-cluster\"\n\tresource: {\n\t\tapiVersion: \"nobu.dev/v1\"\n\t\tkind:       \"Cluster\"\n\t\tmetadata: name: \"example-cluster\"\n\t}\n}\nnodepool: {\n\tname: \"example-nodepool\"\n\tresource: {\n\t\tapiVersion: \"nobu.dev/v1\"\n\t\tkind:       \"Nodepool\"\n\t\tmetadata: name: \"example-nodepool\"\n\t}\n}\nvpc: {\n\tname: \"example-vpc\"\n\tresource: {\n\t\tapiVersion: \"nobu.dev/v1\"\n\t\tkind:       \"Vpc\"\n\t\tmetadata: name: \"example-vpc\"\n\t}\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -436,7 +436,7 @@ func TestRunFunction(t *testing.T) {
 								]
 							},
 							"target": "Resources",
-							"value": "output: [\n\t{\n\t\tname: \"example-cluster\"\n\t\tbase: {\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Cluster\"\n\t\t}\n\t},\n\t{\n\t\tname: \"example-nodepool\"\n\t\tbase: {\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Nodepool\"\n\t\t}\n\t},\n\t{\n\t\tname: \"example-vpc\"\n\t\tbase: {\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Vpc\"\n\t\t}\n\t},\n\t{\n\t\tname: \"example-rds\"\n\t\tbase: {\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Rds\"\n\t\t}\n\t},\n\t{\n\t\tname: \"example-subnet\"\n\t\tbase: {\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Subnet\"\n\t\t}\n\t},\n]\n"
+							"value": "output: [\n\t{\n\t\tname: \"example-cluster\"\n\t\tresource: {\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Cluster\"\n\t\t}\n\t},\n\t{\n\t\tname: \"example-nodepool\"\n\t\tresource: {\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Nodepool\"\n\t\t}\n\t},\n\t{\n\t\tname: \"example-vpc\"\n\t\tresource: {\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Vpc\"\n\t\t}\n\t},\n\t{\n\t\tname: \"example-rds\"\n\t\tresource: {\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Rds\"\n\t\t}\n\t},\n\t{\n\t\tname: \"example-subnet\"\n\t\tresource: {\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Subnet\"\n\t\t}\n\t},\n]\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -528,7 +528,7 @@ func TestRunFunction(t *testing.T) {
 								]
 							},
 							"target": "Resources",
-							"value": "#deployment: [ID=_]: {\n\tname: ID\n\tbase: {\n\t\tapiVersion: \"apps/v1\"\n\t\tkind:       \"Deployment\"\n\t\tspec: {\n\t\t\treplicas: *1 | int\n\t\t\ttemplate: {\n\t\t\t\tmetadata: labels: {\n\t\t\t\t\tapp:       ID\n\t\t\t\t\tdomain:    \"prod\"\n\t\t\t\t\tcomponent: string\n\t\t\t\t}\n\t\t\t\tspec: containers: [{name: ID}]\n\t\t\t}\n\t\t}\n\t}\n}\n\n#deployment: echoserver: base: spec: template: {\n\tmetadata: annotations: {\n\t\t\"prometheus.io.scrape\": \"true\"\n\t\t\"prometheus.io.port\":   \"7080\"\n\t}\n\tmetadata: labels: {\n\t\t\"component\": \"core\"\n\t}\n}\n"
+							"value": "#deployment: [ID=_]: {\n\tname: ID\n\tresource: {\n\t\tapiVersion: \"apps/v1\"\n\t\tkind:       \"Deployment\"\n\t\tspec: {\n\t\t\treplicas: *1 | int\n\t\t\ttemplate: {\n\t\t\t\tmetadata: labels: {\n\t\t\t\t\tapp:       ID\n\t\t\t\t\tdomain:    \"prod\"\n\t\t\t\t\tcomponent: string\n\t\t\t\t}\n\t\t\t\tspec: containers: [{name: ID}]\n\t\t\t}\n\t\t}\n\t}\n}\n\n#deployment: echoserver: resource: spec: template: {\n\tmetadata: annotations: {\n\t\t\"prometheus.io.scrape\": \"true\"\n\t\t\"prometheus.io.port\":   \"7080\"\n\t}\n\tmetadata: labels: {\n\t\t\"component\": \"core\"\n\t}\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -606,7 +606,7 @@ func TestRunFunction(t *testing.T) {
 								]
 							},
 							"target": "Resources",
-							"value": "#env: string @tag(env)\n\nname: \"example\"\nbase: {\n\tapiVersion: \"eks.nobu.dev/v1\"\n\tkind:       \"Cluster\"\n\tmetadata: {\n\t\tannotations: {\n\t\t\tregion: \"us-east-1\"\n\t\t}\n\t\tlabels: {\n\t\t\tapp:            \"example\"\n\t\t\tenv:            #env\n\t\t\tclassification: \"controlplane\"\n\t\t}\n\t}\n}\n"
+							"value": "#env: string @tag(env)\n\nname: \"example\"\nresource: {\n\tapiVersion: \"eks.nobu.dev/v1\"\n\tkind:       \"Cluster\"\n\tmetadata: {\n\t\tannotations: {\n\t\t\tregion: \"us-east-1\"\n\t\t}\n\t\tlabels: {\n\t\t\tapp:            \"example\"\n\t\t\tenv:            #env\n\t\t\tclassification: \"controlplane\"\n\t\t}\n\t}\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -683,7 +683,7 @@ func TestRunFunction(t *testing.T) {
 								]
 							},
 							"target": "Resources",
-							"value": "#env:    string @tag(env,short=development|staging|production)\n#region: string @tag(region)\n\ncluster: [ID=_]: {\n\tname: ID\n\tbase: {\n\t\tapiVersion: \"eks.nobu.dev/v1\"\n\t\tkind:       \"Cluster\"\n\t\tmetadata: labels: {\n\t\t\tapp:            ID\n\t\t\tenv:            #env\n\t\t\tclassification: string\n\t\t}\n\t\t// we always have one namesake container\n\t}\n}\ncluster: example: base: metadata: {\n\tannotations: {\n\t\t\"region\": #region\n\t}\n\tlabels: {\n\t\t\"classification\": \"controlplane\"\n\t}\n}\n"
+							"value": "#env:    string @tag(env,short=development|staging|production)\n#region: string @tag(region)\n\ncluster: [ID=_]: {\n\tname: ID\n\tresource: {\n\t\tapiVersion: \"eks.nobu.dev/v1\"\n\t\tkind:       \"Cluster\"\n\t\tmetadata: labels: {\n\t\t\tapp:            ID\n\t\t\tenv:            #env\n\t\t\tclassification: string\n\t\t}\n\t\t// we always have one namesake container\n\t}\n}\ncluster: example: resource: metadata: {\n\tannotations: {\n\t\t\"region\": #region\n\t}\n\tlabels: {\n\t\t\"classification\": \"controlplane\"\n\t}\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -745,7 +745,7 @@ func TestRunFunction(t *testing.T) {
 						},
 						"export": {
 							"target": "XR",
-							"value": "name: \"example\"\nbase: {\n\tmetadata: name: \"example\"\n\tmetadata: labels: {\n\t\tapp:            \"example\"\n\t\tenv:            \"prod\"\n\t\tclassification: \"controlplane\"\n\t}\n}\n"
+							"value": "name: \"example\"\nresource: {\n\tmetadata: name: \"example\"\n\tmetadata: labels: {\n\t\tapp:            \"example\"\n\t\tenv:            \"prod\"\n\t\tclassification: \"controlplane\"\n\t}\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -802,7 +802,7 @@ func TestRunFunction(t *testing.T) {
 						"export": {
 							"target": "XR",
 							"overwrite": true,
-							"value": "name: \"patch-example\"\nbase: {\n\tkind: \"Overwrite\"\n\tmetadata: name: \"example\"\n}\n"
+							"value": "name: \"patch-example\"\nresource: {\n\tkind: \"Overwrite\"\n\tmetadata: name: \"example\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -847,7 +847,7 @@ func TestRunFunction(t *testing.T) {
 						},
 						"export": {
 							"target": "PatchDesired",
-							"value": "name: \"patch-existing\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
+							"value": "name: \"patch-existing\"\nresource: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -919,7 +919,7 @@ func TestRunFunction(t *testing.T) {
 						},
 						"export": {
 							"target": "PatchDesired",
-							"value": "name: \"patch-existing\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
+							"value": "name: \"patch-existing\"\nresource: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -1057,7 +1057,7 @@ func TestRunFunction(t *testing.T) {
 									}
 								}
 							],
-							"value": "name: \"example-cluster\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
+							"value": "name: \"example-cluster\"\nresource: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -1130,7 +1130,7 @@ func TestRunFunction(t *testing.T) {
 									}
 								}
 							],
-							"value": "name: \"example-cluster\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tmetadata: annotations: \"kubernetes.io/newone\": \"hello\"\n}\n"
+							"value": "name: \"example-cluster\"\nresource: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tmetadata: annotations: \"kubernetes.io/newone\": \"hello\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -1203,7 +1203,7 @@ func TestRunFunction(t *testing.T) {
 									}
 								}
 							],
-							"value": "name: \"example-cluster\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tmetadata: annotations: \"kubernetes.io/serviceaccount\": \"newsa\"\n}\n"
+							"value": "name: \"example-cluster\"\nresource: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tmetadata: annotations: \"kubernetes.io/serviceaccount\": \"newsa\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -1275,7 +1275,7 @@ func TestRunFunction(t *testing.T) {
 									}
 								}
 							],
-							"value": "name: \"example-cluster\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tmetadata: labels: \"additional\": \"news\"\n}\n"
+							"value": "name: \"example-cluster\"\nresource: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tmetadata: labels: \"additional\": \"news\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -1368,7 +1368,7 @@ func TestRunFunction(t *testing.T) {
 									}
 								}
 							],
-							"value": "output: [\n\t{\n\t\tname: \"bucket\"\n\t\tbase: {\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Bucket\"\n\t\t\tmetadata: name: \"test-bucket\"\n\n\t\t\t// Add fields here\n\t\t\tmetadata: annotations: {\n\t\t\t\t\"nobu.dev/cueified\": \"true\"\n\t\t\t\t\"nobu.dev/app\":      \"someapp\"\n\t\t\t}\n\n\t\t\tspec: forProvider: policy: \"some-bucket-policy\"\n\t\t}\n\t},\n\t{\n\t\tname: \"iam-user\"\n\t\tbase: {\n\t\t\t// Target the user by name\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"User\"\n\t\t\tmetadata: name: \"test-user\"\n\n\t\t\t// Add fields here\n\t\t\tmetadata: annotations: {\n\t\t\t\t\"nobu.dev/cueified\": \"true\"\n\t\t\t\t\"nobu.dev/app\":      \"someapp\"\n\t\t\t}\n\n\t\t\tspec: forProvider: name: \"somename\"\n\t\t}\n\t},\n\t{\n\t\tname: \"iam-role\"\n\t\tbase: {\n\t\t\t// Target the bucket by name\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Role\"\n\t\t\tmetadata: name: \"test-role\"\n\n\t\t\t// Add fields here\n\t\t\tmetadata: annotations: {\n\t\t\t\t\"nobu.dev/cueified\": \"true\"\n\t\t\t\t\"nobu.dev/app\":      \"someapp\"\n\t\t\t}\n\n\t\t\tspec: forProvider: policy: \"some-role-policy\"\n\t\t}\n\t},\n]\n"
+							"value": "output: [\n\t{\n\t\tname: \"bucket\"\n\t\tresource: {\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Bucket\"\n\t\t\tmetadata: name: \"test-bucket\"\n\n\t\t\t// Add fields here\n\t\t\tmetadata: annotations: {\n\t\t\t\t\"nobu.dev/cueified\": \"true\"\n\t\t\t\t\"nobu.dev/app\":      \"someapp\"\n\t\t\t}\n\n\t\t\tspec: forProvider: policy: \"some-bucket-policy\"\n\t\t}\n\t},\n\t{\n\t\tname: \"iam-user\"\n\t\tresource: {\n\t\t\t// Target the user by name\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"User\"\n\t\t\tmetadata: name: \"test-user\"\n\n\t\t\t// Add fields here\n\t\t\tmetadata: annotations: {\n\t\t\t\t\"nobu.dev/cueified\": \"true\"\n\t\t\t\t\"nobu.dev/app\":      \"someapp\"\n\t\t\t}\n\n\t\t\tspec: forProvider: name: \"somename\"\n\t\t}\n\t},\n\t{\n\t\tname: \"iam-role\"\n\t\tresource: {\n\t\t\t// Target the bucket by name\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Role\"\n\t\t\tmetadata: name: \"test-role\"\n\n\t\t\t// Add fields here\n\t\t\tmetadata: annotations: {\n\t\t\t\t\"nobu.dev/cueified\": \"true\"\n\t\t\t\t\"nobu.dev/app\":      \"someapp\"\n\t\t\t}\n\n\t\t\tspec: forProvider: policy: \"some-role-policy\"\n\t\t}\n\t},\n]\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -1504,7 +1504,7 @@ func TestRunFunction(t *testing.T) {
 									}
 								}
 							],
-							"value": "name: \"example-nodepool\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
+							"value": "name: \"example-nodepool\"\nresource: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -1591,7 +1591,7 @@ func TestRunFunction(t *testing.T) {
 									}
 								}
 							],
-							"value": "name: \"example-cluster\"\nconnectionDetails: [\n\t{\n\t\tName:                    \"testname\"\n\t\tType:                    \"FromConnectionSecretKey\"\n\t\tFromConnectionSecretKey: \"thisisthekey\"\n\t},\n]\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
+							"value": "name: \"example-cluster\"\nconnectionDetails: [\n\t{\n\t\tName:                    \"testname\"\n\t\tType:                    \"FromConnectionSecretKey\"\n\t\tFromConnectionSecretKey: \"thisisthekey\"\n\t},\n]\nresource: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -1677,7 +1677,7 @@ func TestRunFunction(t *testing.T) {
 									}
 								}
 							],
-							"value": "name: \"example-cluster\"\nreadinessChecks: [\n\t{\n\t\tType: \"MatchCondition\"\n\t\tMatchCondition: Type:   \"Ready\"\n\t\tMatchCondition: Status: \"True\"\n\t},\n]\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
+							"value": "name: \"example-cluster\"\nreadinessChecks: [\n\t{\n\t\tType: \"MatchCondition\"\n\t\tMatchCondition: Type:   \"Ready\"\n\t\tMatchCondition: Status: \"True\"\n\t},\n]\nresource: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -1794,7 +1794,7 @@ func TestRunFunctionFailures(t *testing.T) {
 					Results: []*fnv1beta1.Result{
 						{
 							Severity: fnv1beta1.Severity_SEVERITY_FATAL,
-							Message:  "invalid function input: value cannot be empty",
+							Message:  "invalid function input: export.value: Required value: cue template cannot be empty",
 						},
 					},
 				},
@@ -1827,7 +1827,7 @@ func TestRunFunctionFailures(t *testing.T) {
 									}
 								}
 							],
-							"value": "name: \"example-cluster\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name:    \"testname\"\n\tspec: conflicting: \"setattempt\"\n}\n"
+							"value": "name: \"example-cluster\"\nresource: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name:    \"testname\"\n\tspec: conflicting: \"setattempt\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -1882,7 +1882,7 @@ func TestRunFunctionFailures(t *testing.T) {
 									}
 								}
 							],
-							"value": "name: \"example-cluster\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: metadata: annotations: {\n\t\t\"rbac.authorization.k8s.io/autoupdate\": \"true\"\n\t}\n}\n"
+							"value": "name: \"example-cluster\"\nresource: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: metadata: annotations: {\n\t\t\"rbac.authorization.k8s.io/autoupdate\": \"true\"\n\t}\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -1918,7 +1918,7 @@ func TestRunFunctionFailures(t *testing.T) {
 						},
 						"export": {
 							"target": "XR",
-							"value": "name: \"example-xr\"\nbase: {\n\tkind: \"Overwrite\"\n\tmetadata: name: \"example\"\n}\n"
+							"value": "name: \"example-xr\"\nresource: {\n\tkind: \"Overwrite\"\n\tmetadata: name: \"example\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -1975,7 +1975,7 @@ func TestRunFunctionFailures(t *testing.T) {
 									}
 								}
 							],
-							"value": "name: \"testname\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
+							"value": "name: \"testname\"\nresource: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -2053,7 +2053,7 @@ func TestRunFunctionFailures(t *testing.T) {
 									}
 								}
 							],
-							"value": "name: \"testname\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
+							"value": "name: \"testname\"\nresource: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -2105,7 +2105,7 @@ func TestRunFunctionFailures(t *testing.T) {
 									}
 								}
 							],
-							"value": "name: \"example-cluster\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tmetadata: annotations: \"kubernetes.io/serviceaccount\": \"newsa\"\n}\n"
+							"value": "name: \"example-cluster\"\nresource: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tmetadata: annotations: \"kubernetes.io/serviceaccount\": \"newsa\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{

--- a/fn_test.go
+++ b/fn_test.go
@@ -1952,7 +1952,7 @@ func TestRunFunctionFailures(t *testing.T) {
 			},
 		},
 		"FailMatchingTargets": {
-			reason: "PatchResources targeting should fail if gvk+name do not match",
+			reason: "PatchResources targeting should fail if names do not match",
 			args: args{
 				req: &fnv1beta1.RunFunctionRequest{
 					Input: resource.MustStructJSON(`{

--- a/fn_test.go
+++ b/fn_test.go
@@ -47,7 +47,7 @@ func TestRunFunction(t *testing.T) {
 						},
 						"export": {
 							"target": "Resources",
-							"value": "apiVersion: \"example.org/v1\"\nkind: \"Generated\"\nmetadata: name: \"basic\""
+							"value": "name: \"basic\"\nbase: {\n\tapiVersion: \"example.org/v1\"\n\tkind:       \"Generated\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -63,7 +63,7 @@ func TestRunFunction(t *testing.T) {
 					Results: []*fnv1beta1.Result{
 						{
 							Severity: fnv1beta1.Severity_SEVERITY_NORMAL,
-							Message:  "created resource \"basic:Generated\"",
+							Message:  "created resource \":Generated\"",
 						},
 					},
 					Desired: &fnv1beta1.State{
@@ -72,7 +72,7 @@ func TestRunFunction(t *testing.T) {
 						},
 						Resources: map[string]*fnv1beta1.Resource{
 							"basic": {
-								Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"Generated","metadata":{"name":"basic"}}`),
+								Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"Generated"}`),
 							},
 						},
 					},
@@ -91,7 +91,7 @@ func TestRunFunction(t *testing.T) {
 						},
 						"export": {
 							"target": "Resources",
-							"value": "let #ENV = {\n\tPROVIDER: \"aws\"\n}\n\nif #ENV[\"PROVIDER\"] == \"aws\" {\n\tapiVersion: \"eks.nobu.dev/v1beta\"\n}\nif #ENV[\"PROVIDER\"] == \"gcp\" {\n\tapiVersion: \"gke.nobu.dev/v1beta1\"\n}\n\nkind: \"XNodepool\"\nmetadata: name: \"TestNodepool\"\nspec: parameters: {\n\tautoscaling: [{\n\t\tmaxNodeCount: 1\n\t\tminNodeCount: 1\n\t}]\n\tclusterName: \"example1\"\n\tif #ENV[\"LABELS\"] != _|_ {\n\t\tnodeLabels: #ENV[\"LABELS\"]\n\t}\n\tregion: \"us-east-2\"\n}\n"
+							"value": " let #ENV = {\n\tPROVIDER: \"aws\"\n}\n\nname: \"conditional\"\nbase: {\n\tif #ENV[\"PROVIDER\"] == \"aws\" {\n\t\tapiVersion: \"eks.nobu.dev/v1beta\"\n\t}\n\tif #ENV[\"PROVIDER\"] == \"gcp\" {\n\t\tapiVersion: \"gke.nobu.dev/v1beta1\"\n\t}\n\n\tkind: \"XNodepool\"\n\tspec: parameters: {\n\t\tautoscaling: [{\n\t\t\tmaxNodeCount: 1\n\t\t\tminNodeCount: 1\n\t\t}]\n\t\tclusterName: \"example1\"\n\t\tif #ENV[\"LABELS\"] != _|_ {\n\t\t\tnodeLabels: #ENV[\"LABELS\"]\n\t\t}\n\t\tregion: \"us-east-2\"\n\t}\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -107,7 +107,7 @@ func TestRunFunction(t *testing.T) {
 					Results: []*fnv1beta1.Result{
 						{
 							Severity: fnv1beta1.Severity_SEVERITY_NORMAL,
-							Message:  "created resource \"TestNodepool:XNodepool\"",
+							Message:  "created resource \":XNodepool\"",
 						},
 					},
 					Desired: &fnv1beta1.State{
@@ -119,9 +119,6 @@ func TestRunFunction(t *testing.T) {
 								Resource: resource.MustStructJSON(`{
 								    "apiVersion": "eks.nobu.dev/v1beta",
 								    "kind": "XNodepool",
-								    "metadata": {
-								        "name": "TestNodepool"
-								    },
 								    "spec": {
 								        "parameters": {
 								            "autoscaling": [
@@ -153,7 +150,7 @@ func TestRunFunction(t *testing.T) {
 						},
 						"export": {
 							"target": "Resources",
-							"value": "#deployment: [ID=_]: {\n\tapiVersion: \"apps/v1\"\n\tkind:       \"Deployment\"\n\tmetadata: name: ID\n\tspec: {\n\t\treplicas: *1 | int\n\t\ttemplate: {\n\t\t\tmetadata: labels: {\n\t\t\t\tapp:       ID\n\t\t\t\tdomain:    \"prod\"\n\t\t\t\tcomponent: string\n\t\t\t}\n\t\t\tspec: containers: [{name: ID}]\n\t\t}\n\t}\n}\n\n#deployment: echoserver: spec: template: {\n\tmetadata: annotations: {\n\t\t\"prometheus.io.scrape\": \"true\"\n\t\t\"prometheus.io.port\":   \"7080\"\n\t}\n\tmetadata: labels: {\n\t\t\"component\": \"core\"\n\t}\n}\n#deployment.echoserver\n"
+							"value": "#deployment: [ID=_]: {\n\tapiVersion: \"apps/v1\"\n\tkind:       \"Deployment\"\n\tmetadata: name: ID\n\tspec: {\n\t\treplicas: *1 | int\n\t\ttemplate: {\n\t\t\tmetadata: labels: {\n\t\t\t\tapp:       ID\n\t\t\t\tdomain:    \"prod\"\n\t\t\t\tcomponent: string\n\t\t\t}\n\t\t\tspec: containers: [{name: ID}]\n\t\t}\n\t}\n}\n\n#deployment: echoserver: spec: template: {\n\tmetadata: annotations: {\n\t\t\"prometheus.io.scrape\": \"true\"\n\t\t\"prometheus.io.port\":   \"7080\"\n\t}\n\tmetadata: labels: {\n\t\t\"component\": \"core\"\n\t}\n}\n\nname: \"identifier\"\nbase: #deployment.echoserver\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -177,7 +174,7 @@ func TestRunFunction(t *testing.T) {
 							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR"}`),
 						},
 						Resources: map[string]*fnv1beta1.Resource{
-							"identification": {
+							"identifier": {
 								Resource: resource.MustStructJSON(`{
 									"apiVersion": "apps/v1",
 									"kind": "Deployment",
@@ -215,7 +212,7 @@ func TestRunFunction(t *testing.T) {
 			},
 		},
 		// Expressions allow for multiple document generations
-		"YAMLStreamExpressions": {
+		"JSONStreamExpressions": {
 			reason: "CUE Expressions should work",
 			args: args{
 				req: &fnv1beta1.RunFunctionRequest{
@@ -232,7 +229,7 @@ func TestRunFunction(t *testing.T) {
 								]
 							},
 							"target": "Resources",
-							"value": "output: [\n\t{\n\t\tapiVersion: \"nobu.dev/v1\"\n\t\tkind:       \"Cluster\"\n\t\tmetadata: name: \"example-cluster\"\n\t},\n\t{\n\t\tapiVersion: \"nobu.dev/v1\"\n\t\tkind:       \"Nodepool\"\n\t\tmetadata: name: \"example-nodepool\"\n\t},\n]\n"
+							"value": "output: [\n\t{\n\t\tname: \"example-cluster\"\n\t\tbase: {\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Cluster\"\n\t\t}\n\t},\n\t{\n\t\tname: \"example-nodepool\"\n\t\tbase: {\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Nodepool\"\n\t\t}\n\t},\n]\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -248,11 +245,11 @@ func TestRunFunction(t *testing.T) {
 					Results: []*fnv1beta1.Result{
 						{
 							Severity: fnv1beta1.Severity_SEVERITY_NORMAL,
-							Message:  "created resource \"example-cluster:Cluster\"",
+							Message:  "created resource \":Cluster\"",
 						},
 						{
 							Severity: fnv1beta1.Severity_SEVERITY_NORMAL,
-							Message:  "created resource \"example-nodepool:Nodepool\"",
+							Message:  "created resource \":Nodepool\"",
 						},
 					},
 					Desired: &fnv1beta1.State{
@@ -263,19 +260,13 @@ func TestRunFunction(t *testing.T) {
 							"expression-example-cluster": {
 								Resource: resource.MustStructJSON(`{
 									"apiVersion": "nobu.dev/v1",
-									"kind": "Cluster",
-									"metadata": {
-									    "name": "example-cluster"
-									}
+									"kind": "Cluster"
 								}`),
 							},
 							"expression-example-nodepool": {
 								Resource: resource.MustStructJSON(`{
 									"apiVersion": "nobu.dev/v1",
-									"kind": "Nodepool",
-									"metadata": {
-									    "name": "example-nodepool"
-									}
+									"kind": "Nodepool"
 								}`),
 							},
 						},
@@ -283,7 +274,7 @@ func TestRunFunction(t *testing.T) {
 				},
 			},
 		},
-		"JSONStreamExpressions": {
+		"YAMLStreamExpressions": {
 			reason: "CUE Expressions should work",
 			args: args{
 				req: &fnv1beta1.RunFunctionRequest{
@@ -300,7 +291,7 @@ func TestRunFunction(t *testing.T) {
 								]
 							},
 							"target": "Resources",
-							"value": "output: [\n\t{\n\t\tapiVersion: \"nobu.dev/v1\"\n\t\tkind:       \"Cluster\"\n\t\tmetadata: name: \"example-cluster\"\n\t},\n\t{\n\t\tapiVersion: \"nobu.dev/v1\"\n\t\tkind:       \"Nodepool\"\n\t\tmetadata: name: \"example-nodepool\"\n\t},\n]\n"
+							"value": "output: [\n\t{\n\t\tname: \"example-cluster\"\n\t\tbase: {\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Cluster\"\n\t\t}\n\t},\n\t{\n\t\tname: \"example-nodepool\"\n\t\tbase: {\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Nodepool\"\n\t\t}\n\t},\n]\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -316,11 +307,11 @@ func TestRunFunction(t *testing.T) {
 					Results: []*fnv1beta1.Result{
 						{
 							Severity: fnv1beta1.Severity_SEVERITY_NORMAL,
-							Message:  "created resource \"example-cluster:Cluster\"",
+							Message:  "created resource \":Cluster\"",
 						},
 						{
 							Severity: fnv1beta1.Severity_SEVERITY_NORMAL,
-							Message:  "created resource \"example-nodepool:Nodepool\"",
+							Message:  "created resource \":Nodepool\"",
 						},
 					},
 					Desired: &fnv1beta1.State{
@@ -331,19 +322,13 @@ func TestRunFunction(t *testing.T) {
 							"expression-example-cluster": {
 								Resource: resource.MustStructJSON(`{
 									"apiVersion": "nobu.dev/v1",
-									"kind": "Cluster",
-									"metadata": {
-									    "name": "example-cluster"
-									}
+									"kind": "Cluster"
 								}`),
 							},
 							"expression-example-nodepool": {
 								Resource: resource.MustStructJSON(`{
 									"apiVersion": "nobu.dev/v1",
-									"kind": "Nodepool",
-									"metadata": {
-									    "name": "example-nodepool"
-									}
+									"kind": "Nodepool"
 								}`),
 							},
 						},
@@ -370,7 +355,7 @@ func TestRunFunction(t *testing.T) {
 								]
 							},
 							"target": "Resources",
-							"value": "cluster: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"Cluster\"\n\tmetadata: name: \"example-cluster\"\n}\nnodepool: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"Nodepool\"\n\tmetadata: name: \"example-nodepool\"\n}\nvpc: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"Vpc\"\n\tmetadata: name: \"example-vpc\"\n}\n"
+							"value": "cluster: {\n\tname: \"example-cluster\"\n\tbase: {\n\t\tapiVersion: \"nobu.dev/v1\"\n\t\tkind:       \"Cluster\"\n\t\tmetadata: name: \"example-cluster\"\n\t}\n}\nnodepool: {\n\tname: \"example-nodepool\"\n\tbase: {\n\t\tapiVersion: \"nobu.dev/v1\"\n\t\tkind:       \"Nodepool\"\n\t\tmetadata: name: \"example-nodepool\"\n\t}\n}\nvpc: {\n\tname: \"example-vpc\"\n\tbase: {\n\t\tapiVersion: \"nobu.dev/v1\"\n\t\tkind:       \"Vpc\"\n\t\tmetadata: name: \"example-vpc\"\n\t}\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -407,7 +392,7 @@ func TestRunFunction(t *testing.T) {
 									"apiVersion": "nobu.dev/v1",
 									"kind": "Cluster",
 									"metadata": {
-									    "name": "example-cluster"
+										"name": "example-cluster"
 									}
 								}`),
 							},
@@ -416,7 +401,7 @@ func TestRunFunction(t *testing.T) {
 									"apiVersion": "nobu.dev/v1",
 									"kind": "Nodepool",
 									"metadata": {
-									    "name": "example-nodepool"
+										"name": "example-nodepool"
 									}
 								}`),
 							},
@@ -425,7 +410,7 @@ func TestRunFunction(t *testing.T) {
 									"apiVersion": "nobu.dev/v1",
 									"kind": "Vpc",
 									"metadata": {
-									    "name": "example-vpc"
+										"name": "example-vpc"
 									}
 								}`),
 							},
@@ -451,7 +436,7 @@ func TestRunFunction(t *testing.T) {
 								]
 							},
 							"target": "Resources",
-							"value": "output: [\n\t{\n\t\tapiVersion: \"nobu.dev/v1\"\n\t\tkind:       \"Cluster\"\n\t\tmetadata: name: \"example-cluster\"\n\t},\n\t{\n\t\tapiVersion: \"nobu.dev/v1\"\n\t\tkind:       \"Nodepool\"\n\t\tmetadata: name: \"example-nodepool\"\n\t},\n\t{\n\t\tapiVersion: \"nobu.dev/v1\"\n\t\tkind:       \"Vpc\"\n\t\tmetadata: name: \"example-vpc\"\n\t},\n\t{\n\t\tapiVersion: \"nobu.dev/v1\"\n\t\tkind:       \"Rds\"\n\t\tmetadata: name: \"example-rds\"\n\t},\n\t{\n\t\tapiVersion: \"nobu.dev/v1\"\n\t\tkind:       \"Subnet\"\n\t\tmetadata: name: \"example-subnet\"\n\t},\n]\n"
+							"value": "output: [\n\t{\n\t\tname: \"example-cluster\"\n\t\tbase: {\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Cluster\"\n\t\t}\n\t},\n\t{\n\t\tname: \"example-nodepool\"\n\t\tbase: {\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Nodepool\"\n\t\t}\n\t},\n\t{\n\t\tname: \"example-vpc\"\n\t\tbase: {\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Vpc\"\n\t\t}\n\t},\n\t{\n\t\tname: \"example-rds\"\n\t\tbase: {\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Rds\"\n\t\t}\n\t},\n\t{\n\t\tname: \"example-subnet\"\n\t\tbase: {\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Subnet\"\n\t\t}\n\t},\n]\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -467,23 +452,23 @@ func TestRunFunction(t *testing.T) {
 					Results: []*fnv1beta1.Result{
 						{
 							Severity: fnv1beta1.Severity_SEVERITY_NORMAL,
-							Message:  "created resource \"example-cluster:Cluster\"",
+							Message:  "created resource \":Cluster\"",
 						},
 						{
 							Severity: fnv1beta1.Severity_SEVERITY_NORMAL,
-							Message:  "created resource \"example-nodepool:Nodepool\"",
+							Message:  "created resource \":Nodepool\"",
 						},
 						{
 							Severity: fnv1beta1.Severity_SEVERITY_NORMAL,
-							Message:  "created resource \"example-rds:Rds\"",
+							Message:  "created resource \":Rds\"",
 						},
 						{
 							Severity: fnv1beta1.Severity_SEVERITY_NORMAL,
-							Message:  "created resource \"example-subnet:Subnet\"",
+							Message:  "created resource \":Subnet\"",
 						},
 						{
 							Severity: fnv1beta1.Severity_SEVERITY_NORMAL,
-							Message:  "created resource \"example-vpc:Vpc\"",
+							Message:  "created resource \":Vpc\"",
 						},
 					},
 					Desired: &fnv1beta1.State{
@@ -494,46 +479,31 @@ func TestRunFunction(t *testing.T) {
 							"expression-example-cluster": {
 								Resource: resource.MustStructJSON(`{
 									"apiVersion": "nobu.dev/v1",
-									"kind": "Cluster",
-									"metadata": {
-									    "name": "example-cluster"
-									}
+									"kind": "Cluster"
 								}`),
 							},
 							"expression-example-nodepool": {
 								Resource: resource.MustStructJSON(`{
 									"apiVersion": "nobu.dev/v1",
-									"kind": "Nodepool",
-									"metadata": {
-									    "name": "example-nodepool"
-									}
+									"kind": "Nodepool"
 								}`),
 							},
 							"expression-example-vpc": {
 								Resource: resource.MustStructJSON(`{
 									"apiVersion": "nobu.dev/v1",
-									"kind": "Vpc",
-									"metadata": {
-									    "name": "example-vpc"
-									}
+									"kind": "Vpc"
 								}`),
 							},
 							"expression-example-rds": {
 								Resource: resource.MustStructJSON(`{
 									"apiVersion": "nobu.dev/v1",
-									"kind": "Rds",
-									"metadata": {
-									    "name": "example-rds"
-									}
+									"kind": "Rds"
 								}`),
 							},
 							"expression-example-subnet": {
 								Resource: resource.MustStructJSON(`{
 									"apiVersion": "nobu.dev/v1",
-									"kind": "Subnet",
-									"metadata": {
-									    "name": "example-subnet"
-									}
+									"kind": "Subnet"
 								}`),
 							},
 						},
@@ -558,7 +528,7 @@ func TestRunFunction(t *testing.T) {
 								]
 							},
 							"target": "Resources",
-							"value": "#deployment: [ID=_]: {\n\tapiVersion: \"apps/v1\"\n\tkind:       \"Deployment\"\n\tmetadata: name: ID\n\tspec: {\n\t\treplicas: *1 | int\n\t\ttemplate: {\n\t\t\tmetadata: labels: {\n\t\t\t\tapp:       ID\n\t\t\t\tdomain:    \"prod\"\n\t\t\t\tcomponent: string\n\t\t\t}\n\t\t\tspec: containers: [{name: ID}]\n\t\t}\n\t}\n}\n\n#deployment: echoserver: spec: template: {\n\tmetadata: annotations: {\n\t\t\"prometheus.io.scrape\": \"true\"\n\t\t\"prometheus.io.port\":   \"7080\"\n\t}\n\tmetadata: labels: {\n\t\t\"component\": \"core\"\n\t}\n}\n"
+							"value": "#deployment: [ID=_]: {\n\tname: ID\n\tbase: {\n\t\tapiVersion: \"apps/v1\"\n\t\tkind:       \"Deployment\"\n\t\tspec: {\n\t\t\treplicas: *1 | int\n\t\t\ttemplate: {\n\t\t\t\tmetadata: labels: {\n\t\t\t\t\tapp:       ID\n\t\t\t\t\tdomain:    \"prod\"\n\t\t\t\t\tcomponent: string\n\t\t\t\t}\n\t\t\t\tspec: containers: [{name: ID}]\n\t\t\t}\n\t\t}\n\t}\n}\n\n#deployment: echoserver: base: spec: template: {\n\tmetadata: annotations: {\n\t\t\"prometheus.io.scrape\": \"true\"\n\t\t\"prometheus.io.port\":   \"7080\"\n\t}\n\tmetadata: labels: {\n\t\t\"component\": \"core\"\n\t}\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -574,7 +544,7 @@ func TestRunFunction(t *testing.T) {
 					Results: []*fnv1beta1.Result{
 						{
 							Severity: fnv1beta1.Severity_SEVERITY_NORMAL,
-							Message:  "created resource \"echoserver:Deployment\"",
+							Message:  "created resource \":Deployment\"",
 						},
 					},
 					Desired: &fnv1beta1.State{
@@ -582,13 +552,10 @@ func TestRunFunction(t *testing.T) {
 							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR"}`),
 						},
 						Resources: map[string]*fnv1beta1.Resource{
-							"expressidentification": {
+							"echoserver": {
 								Resource: resource.MustStructJSON(`{
 									"apiVersion": "apps/v1",
 									"kind": "Deployment",
-									"metadata": {
-									    "name": "echoserver"
-									},
 									"spec": {
 									    "replicas": 1,
 									    "template": {
@@ -639,7 +606,7 @@ func TestRunFunction(t *testing.T) {
 								]
 							},
 							"target": "Resources",
-							"value": "#env: string @tag(env)\n\napiVersion: \"eks.nobu.dev/v1\"\nkind:       \"Cluster\"\nmetadata: {\n\tannotations: {\n\t\tregion: \"us-east-1\"\n\t}\n\tname: \"example\"\n\tlabels: {\n\t\tapp:            \"example\"\n\t\tenv:            #env\n\t\tclassification: \"controlplane\"\n\t}\n}\n"
+							"value": "#env: string @tag(env)\n\nname: \"example\"\nbase: {\n\tapiVersion: \"eks.nobu.dev/v1\"\n\tkind:       \"Cluster\"\n\tmetadata: {\n\t\tannotations: {\n\t\t\tregion: \"us-east-1\"\n\t\t}\n\t\tlabels: {\n\t\t\tapp:            \"example\"\n\t\t\tenv:            #env\n\t\t\tclassification: \"controlplane\"\n\t\t}\n\t}\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -660,7 +627,7 @@ func TestRunFunction(t *testing.T) {
 					Results: []*fnv1beta1.Result{
 						{
 							Severity: fnv1beta1.Severity_SEVERITY_NORMAL,
-							Message:  "created resource \"example:Cluster\"",
+							Message:  "created resource \":Cluster\"",
 						},
 					},
 					Desired: &fnv1beta1.State{
@@ -668,7 +635,7 @@ func TestRunFunction(t *testing.T) {
 							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR","spec":{"env":"prod"}}`),
 						},
 						Resources: map[string]*fnv1beta1.Resource{
-							"injection": {
+							"example": {
 								Resource: resource.MustStructJSON(`{
 									"apiVersion": "eks.nobu.dev/v1",
 									"kind": "Cluster",
@@ -676,7 +643,6 @@ func TestRunFunction(t *testing.T) {
 										"annotations": {
 											"region": "us-east-1"
 										},
-										"name": "example",
 										"labels": {
 											"app": "example",
 											"env": "prod",
@@ -717,7 +683,7 @@ func TestRunFunction(t *testing.T) {
 								]
 							},
 							"target": "Resources",
-							"value": "#env:    string @tag(env,short=development|staging|production)\n#region: string @tag(region)\n\ncluster: [ID=_]: {\n\tapiVersion: \"eks.nobu.dev/v1\"\n\tkind:       \"Cluster\"\n\tmetadata: name: ID\n\tmetadata: labels: {\n\t\tapp:            ID\n\t\tenv:            #env\n\t\tclassification: string\n\t}\n\t// we always have one namesake container\n}\ncluster: example: metadata: {\n\tannotations: {\n\t\t\"region\": #region\n\t}\n\tlabels: {\n\t\t\"classification\": \"controlplane\"\n\t}\n}\n"
+							"value": "#env:    string @tag(env,short=development|staging|production)\n#region: string @tag(region)\n\ncluster: [ID=_]: {\n\tname: ID\n\tbase: {\n\t\tapiVersion: \"eks.nobu.dev/v1\"\n\t\tkind:       \"Cluster\"\n\t\tmetadata: labels: {\n\t\t\tapp:            ID\n\t\t\tenv:            #env\n\t\t\tclassification: string\n\t\t}\n\t\t// we always have one namesake container\n\t}\n}\ncluster: example: base: metadata: {\n\tannotations: {\n\t\t\"region\": #region\n\t}\n\tlabels: {\n\t\t\"classification\": \"controlplane\"\n\t}\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -738,7 +704,7 @@ func TestRunFunction(t *testing.T) {
 					Results: []*fnv1beta1.Result{
 						{
 							Severity: fnv1beta1.Severity_SEVERITY_NORMAL,
-							Message:  "created resource \"example:Cluster\"",
+							Message:  "created resource \":Cluster\"",
 						},
 					},
 					Desired: &fnv1beta1.State{
@@ -746,7 +712,7 @@ func TestRunFunction(t *testing.T) {
 							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR","spec":{"env":"prod", "region":"us-east-1"}}`),
 						},
 						Resources: map[string]*fnv1beta1.Resource{
-							"injectionexpression": {
+							"example": {
 								Resource: resource.MustStructJSON(`{
 									"apiVersion": "eks.nobu.dev/v1",
 									"kind": "Cluster",
@@ -754,7 +720,6 @@ func TestRunFunction(t *testing.T) {
 										"annotations": {
 											"region": "us-east-1"
 										},
-										"name": "example",
 										"labels": {
 											"app": "example",
 											"env": "prod",
@@ -780,7 +745,7 @@ func TestRunFunction(t *testing.T) {
 						},
 						"export": {
 							"target": "XR",
-							"value": "metadata: name: \"example\"\nmetadata: labels: {\n\tapp:            \"example\"\n\tenv:            \"prod\"\n\tclassification: \"controlplane\"\n}\n"
+							"value": "name: \"example\"\nbase: {\n\tmetadata: name: \"example\"\n\tmetadata: labels: {\n\t\tapp:            \"example\"\n\t\tenv:            \"prod\"\n\t\tclassification: \"controlplane\"\n\t}\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -837,7 +802,7 @@ func TestRunFunction(t *testing.T) {
 						"export": {
 							"target": "XR",
 							"overwrite": true,
-							"value": "kind: \"Overwrite\"\nmetadata: name: \"example\"\n"
+							"value": "name: \"patch-example\"\nbase: {\n\tkind: \"Overwrite\"\n\tmetadata: name: \"example\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -882,7 +847,7 @@ func TestRunFunction(t *testing.T) {
 						},
 						"export": {
 							"target": "PatchDesired",
-							"value": "apiVersion: \"nobu.dev/v1\"\nkind: \"findme\"\nmetadata: name: \"testname\"\nspec: forProvider: router: \"somerouter\"\nspec: forProvider: region: \"ap-northeast-1\"\n"
+							"value": "name: \"testname\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -954,7 +919,7 @@ func TestRunFunction(t *testing.T) {
 						},
 						"export": {
 							"target": "PatchDesired",
-							"value": "apiVersion: \"nobu.dev/v1\"\nkind: \"findme\"\nmetadata: name: \"testname\"\nspec: forProvider: router: \"somerouter\"\nspec: forProvider: region: \"ap-northeast-1\"\n"
+							"value": "name: \"testname\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -1092,7 +1057,7 @@ func TestRunFunction(t *testing.T) {
 									}
 								}
 							],
-							"value": "apiVersion: \"nobu.dev/v1\"\nkind: \"findme\"\nmetadata: name: \"testname\"\nspec: forProvider: router: \"somerouter\"\nspec: forProvider: region: \"ap-northeast-1\"\n"
+							"value": "name: \"testname\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -1165,7 +1130,7 @@ func TestRunFunction(t *testing.T) {
 									}
 								}
 							],
-							"value": "apiVersion: \"nobu.dev/v1\"\nkind: \"findme\"\nmetadata: name: \"testname\"\nmetadata: annotations: \"kubernetes.io/newone\": \"hello\"\n"
+							"value": "name: \"testname\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tmetadata: annotations: \"kubernetes.io/newone\": \"hello\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -1238,7 +1203,7 @@ func TestRunFunction(t *testing.T) {
 									}
 								}
 							],
-							"value": "apiVersion: \"nobu.dev/v1\"\nkind: \"findme\"\nmetadata: name: \"testname\"\nmetadata: annotations: \"kubernetes.io/serviceaccount\": \"newsa\"\n"
+							"value": "name: \"testname\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tmetadata: annotations: \"kubernetes.io/serviceaccount\": \"newsa\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -1310,7 +1275,7 @@ func TestRunFunction(t *testing.T) {
 									}
 								}
 							],
-							"value": "apiVersion: \"nobu.dev/v1\"\nkind: \"findme\"\nmetadata: name: \"testname\"\nmetadata: labels: \"additional\": \"news\"\n"
+							"value": "name: \"testname\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tmetadata: labels: \"additional\": \"news\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -1354,7 +1319,6 @@ func TestRunFunction(t *testing.T) {
 				},
 			},
 		},
-
 		"PatchResourcesMultiple": {
 			reason: "PatchResources should be able to patch multiple resources",
 			args: args{
@@ -1404,7 +1368,7 @@ func TestRunFunction(t *testing.T) {
 									}
 								}
 							],
-							"value": "output: [ \n  {\n    // Target the bucket by apiVersion+kind+name\n    apiVersion: \"nobu.dev/v1\"\n    kind: \"Bucket\"\n    metadata: name: \"test-bucket\"\n    \n    // Add fields here\n    metadata: annotations: {\n        \"nobu.dev/cueified\": \"true\",\n        \"nobu.dev/app\": \"someapp\",\n    }\n    \n    spec: forProvider: policy: \"some-bucket-policy\"\n  }, \n  {\n    // Target the user by apiVersion+kind+name\n    apiVersion: \"nobu.dev/v1\"\n    kind: \"User\"\n    metadata: name: \"test-user\"\n    \n    // Add fields here\n    metadata: annotations: {\n        \"nobu.dev/cueified\": \"true\",\n        \"nobu.dev/app\": \"someapp\",\n    }\n\n    spec: forProvider: name: \"somename\"\n  }, \n  {\n    // Target the bucket by apiVersion+kind+name\n    apiVersion: \"nobu.dev/v1\"\n    kind: \"Role\"\n    metadata: name: \"test-role\"\n    \n    // Add fields here\n    metadata: annotations: {\n        \"nobu.dev/cueified\": \"true\",\n        \"nobu.dev/app\": \"someapp\",\n    }\n    \n    spec: forProvider: policy: \"some-role-policy\"\n  },\n]\n\n"
+							"value": "output: [\n\t{\n\t\tname: \"test-bucket\"\n\t\tbase: {\n\t\t\t// Target the bucket by apiVersion+kind+name\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Bucket\"\n\t\t\tmetadata: name: \"test-bucket\"\n\n\t\t\t// Add fields here\n\t\t\tmetadata: annotations: {\n\t\t\t\t\"nobu.dev/cueified\": \"true\"\n\t\t\t\t\"nobu.dev/app\":      \"someapp\"\n\t\t\t}\n\n\t\t\tspec: forProvider: policy: \"some-bucket-policy\"\n\t\t}\n\t},\n\t{\n\t\tname: \"test-user\"\n\t\tbase: {\n\t\t\t// Target the user by apiVersion+kind+name\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"User\"\n\t\t\tmetadata: name: \"test-user\"\n\n\t\t\t// Add fields here\n\t\t\tmetadata: annotations: {\n\t\t\t\t\"nobu.dev/cueified\": \"true\"\n\t\t\t\t\"nobu.dev/app\":      \"someapp\"\n\t\t\t}\n\n\t\t\tspec: forProvider: name: \"somename\"\n\t\t}\n\t},\n\t{\n\t\tname: \"test-role\"\n\t\tbase: {\n\t\t\t// Target the bucket by apiVersion+kind+name\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Role\"\n\t\t\tmetadata: name: \"test-role\"\n\n\t\t\t// Add fields here\n\t\t\tmetadata: annotations: {\n\t\t\t\t\"nobu.dev/cueified\": \"true\"\n\t\t\t\t\"nobu.dev/app\":      \"someapp\"\n\t\t\t}\n\n\t\t\tspec: forProvider: policy: \"some-role-policy\"\n\t\t}\n\t},\n]\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -1540,7 +1504,7 @@ func TestRunFunction(t *testing.T) {
 									}
 								}
 							],
-							"value": "apiVersion: \"nobu.dev/v1\"\nkind: \"findme\"\nmetadata: name: \"testname\"\nspec: forProvider: router: \"somerouter\"\nspec: forProvider: region: \"ap-northeast-1\"\n"
+							"value": "name: \"testname\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -1627,7 +1591,7 @@ func TestRunFunction(t *testing.T) {
 									}
 								}
 							],
-							"value": "#connectionDetails: [\n\t{\n\t\tMatch: {\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"findme\"\n\t\t\tname:       \"testname\"\n\t\t}\n\n\t\tName:                    \"testname\"\n\t\tType:                    \"FromConnectionSecretKey\"\n\t\tFromConnectionSecretKey: \"thisisthekey\"\n\t},\n]\napiVersion: \"nobu.dev/v1\"\nkind: \"findme\"\nmetadata: name: \"testname\"\nspec: forProvider: router: \"somerouter\"\nspec: forProvider: region: \"ap-northeast-1\"\n"
+							"value": "name: \"testname\"\nconnectionDetails: [\n\t{\n\t\tName:                    \"testname\"\n\t\tType:                    \"FromConnectionSecretKey\"\n\t\tFromConnectionSecretKey: \"thisisthekey\"\n\t},\n]\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -1713,7 +1677,7 @@ func TestRunFunction(t *testing.T) {
 									}
 								}
 							],
-							"value": "#readinessChecks: [\n\t{\n\t\tMatch: {\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"findme\"\n\t\t\tname:       \"testname\"\n\t\t}\n\t\tType: \"MatchCondition\"\n\t\tMatchCondition: Type:   \"Ready\"\n\t\tMatchCondition: Status: \"True\"\n\t},\n]\napiVersion: \"nobu.dev/v1\"\nkind: \"findme\"\nmetadata: name: \"testname\"\nspec: forProvider: router: \"somerouter\"\nspec: forProvider: region: \"ap-northeast-1\"\n"
+							"value": "name: \"testname\"\nreadinessChecks: [\n\t{\n\t\tType: \"MatchCondition\"\n\t\tMatchCondition: Type:   \"Ready\"\n\t\tMatchCondition: Status: \"True\"\n\t},\n]\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -1863,7 +1827,7 @@ func TestRunFunctionFailures(t *testing.T) {
 									}
 								}
 							],
-							"value": "apiVersion: \"nobu.dev/v1\"\nkind: \"findme\"\nmetadata: name: \"testname\"\nspec: conflicting: \"setattempt\"\n"
+							"value": "name: \"testname\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name:    \"testname\"\n\tspec: conflicting: \"setattempt\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -1918,7 +1882,7 @@ func TestRunFunctionFailures(t *testing.T) {
 									}
 								}
 							],
-							"value": "apiVersion: \"nobu.dev/v1\"\nkind:       \"findme\"\nmetadata: name: \"testname\"\nspec: metadata: annotations: {\n\t\"rbac.authorization.k8s.io/autoupdate\": \"true\"\n}\n"
+							"value": "name: \"testname\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: metadata: annotations: {\n\t\t\"rbac.authorization.k8s.io/autoupdate\": \"true\"\n\t}\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -1954,7 +1918,7 @@ func TestRunFunctionFailures(t *testing.T) {
 						},
 						"export": {
 							"target": "XR",
-							"value": "kind: \"Overwrite\"\nmetadata: name: \"example\"\n"
+							"value": "name: \"example-xr\"\nbase: {\n\tkind: \"Overwrite\"\n\tmetadata: name: \"example\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -2011,7 +1975,7 @@ func TestRunFunctionFailures(t *testing.T) {
 									}
 								}
 							],
-							"value": "apiVersion: \"nobu.dev/v1\"\nkind: \"findme\"\nmetadata: name: \"testname\"\nspec: forProvider: router: \"somerouter\"\nspec: forProvider: region: \"ap-northeast-1\"\n"
+							"value": "name: \"testname\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -2089,7 +2053,7 @@ func TestRunFunctionFailures(t *testing.T) {
 									}
 								}
 							],
-							"value": "apiVersion: \"nobu.dev/v1\"\nkind: \"findme\"\nmetadata: name: \"testname\"\nspec: forProvider: router: \"somerouter\"\nspec: forProvider: region: \"ap-northeast-1\"\n"
+							"value": "name: \"testname\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -2141,7 +2105,7 @@ func TestRunFunctionFailures(t *testing.T) {
 									}
 								}
 							],
-							"value": "apiVersion: \"nobu.dev/v1\"\nkind: \"findme\"\nmetadata: name: \"testname\"\nmetadata: annotations: \"kubernetes.io/serviceaccount\": \"newsa\"\n"
+							"value": "name: \"testname\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tmetadata: annotations: \"kubernetes.io/serviceaccount\": \"newsa\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{

--- a/fn_test.go
+++ b/fn_test.go
@@ -847,7 +847,7 @@ func TestRunFunction(t *testing.T) {
 						},
 						"export": {
 							"target": "PatchDesired",
-							"value": "name: \"testname\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
+							"value": "name: \"patch-existing\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -879,7 +879,7 @@ func TestRunFunction(t *testing.T) {
 					Results: []*fnv1beta1.Result{
 						{
 							Severity: fnv1beta1.Severity_SEVERITY_NORMAL,
-							Message:  "updated resource \"testname:findme\"",
+							Message:  "updated resource \":findme\"",
 						},
 					},
 					Desired: &fnv1beta1.State{
@@ -919,7 +919,7 @@ func TestRunFunction(t *testing.T) {
 						},
 						"export": {
 							"target": "PatchDesired",
-							"value": "name: \"testname\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
+							"value": "name: \"patch-existing\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -1057,7 +1057,7 @@ func TestRunFunction(t *testing.T) {
 									}
 								}
 							],
-							"value": "name: \"testname\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
+							"value": "name: \"example-cluster\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -1082,7 +1082,7 @@ func TestRunFunction(t *testing.T) {
 							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR"}`),
 						},
 						Resources: map[string]*fnv1beta1.Resource{
-							"testname": {
+							"example-cluster": {
 								Resource: resource.MustStructJSON(`{
 									"apiVersion": "nobu.dev/v1",
 									"kind": "findme",
@@ -1130,7 +1130,7 @@ func TestRunFunction(t *testing.T) {
 									}
 								}
 							],
-							"value": "name: \"testname\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tmetadata: annotations: \"kubernetes.io/newone\": \"hello\"\n}\n"
+							"value": "name: \"example-cluster\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tmetadata: annotations: \"kubernetes.io/newone\": \"hello\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -1155,7 +1155,7 @@ func TestRunFunction(t *testing.T) {
 							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR"}`),
 						},
 						Resources: map[string]*fnv1beta1.Resource{
-							"testname": {
+							"example-cluster": {
 								Resource: resource.MustStructJSON(`{
 									"apiVersion": "nobu.dev/v1",
 									"kind": "findme",
@@ -1203,7 +1203,7 @@ func TestRunFunction(t *testing.T) {
 									}
 								}
 							],
-							"value": "name: \"testname\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tmetadata: annotations: \"kubernetes.io/serviceaccount\": \"newsa\"\n}\n"
+							"value": "name: \"example-cluster\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tmetadata: annotations: \"kubernetes.io/serviceaccount\": \"newsa\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -1228,7 +1228,7 @@ func TestRunFunction(t *testing.T) {
 							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR"}`),
 						},
 						Resources: map[string]*fnv1beta1.Resource{
-							"testname": {
+							"example-cluster": {
 								Resource: resource.MustStructJSON(`{
 									"apiVersion": "nobu.dev/v1",
 									"kind": "findme",
@@ -1275,7 +1275,7 @@ func TestRunFunction(t *testing.T) {
 									}
 								}
 							],
-							"value": "name: \"testname\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tmetadata: labels: \"additional\": \"news\"\n}\n"
+							"value": "name: \"example-cluster\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tmetadata: labels: \"additional\": \"news\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -1300,7 +1300,7 @@ func TestRunFunction(t *testing.T) {
 							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR"}`),
 						},
 						Resources: map[string]*fnv1beta1.Resource{
-							"testname": {
+							"example-cluster": {
 								Resource: resource.MustStructJSON(`{
 									"apiVersion": "nobu.dev/v1",
 									"kind": "findme",
@@ -1368,7 +1368,7 @@ func TestRunFunction(t *testing.T) {
 									}
 								}
 							],
-							"value": "output: [\n\t{\n\t\tname: \"test-bucket\"\n\t\tbase: {\n\t\t\t// Target the bucket by apiVersion+kind+name\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Bucket\"\n\t\t\tmetadata: name: \"test-bucket\"\n\n\t\t\t// Add fields here\n\t\t\tmetadata: annotations: {\n\t\t\t\t\"nobu.dev/cueified\": \"true\"\n\t\t\t\t\"nobu.dev/app\":      \"someapp\"\n\t\t\t}\n\n\t\t\tspec: forProvider: policy: \"some-bucket-policy\"\n\t\t}\n\t},\n\t{\n\t\tname: \"test-user\"\n\t\tbase: {\n\t\t\t// Target the user by apiVersion+kind+name\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"User\"\n\t\t\tmetadata: name: \"test-user\"\n\n\t\t\t// Add fields here\n\t\t\tmetadata: annotations: {\n\t\t\t\t\"nobu.dev/cueified\": \"true\"\n\t\t\t\t\"nobu.dev/app\":      \"someapp\"\n\t\t\t}\n\n\t\t\tspec: forProvider: name: \"somename\"\n\t\t}\n\t},\n\t{\n\t\tname: \"test-role\"\n\t\tbase: {\n\t\t\t// Target the bucket by apiVersion+kind+name\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Role\"\n\t\t\tmetadata: name: \"test-role\"\n\n\t\t\t// Add fields here\n\t\t\tmetadata: annotations: {\n\t\t\t\t\"nobu.dev/cueified\": \"true\"\n\t\t\t\t\"nobu.dev/app\":      \"someapp\"\n\t\t\t}\n\n\t\t\tspec: forProvider: policy: \"some-role-policy\"\n\t\t}\n\t},\n]\n"
+							"value": "output: [\n\t{\n\t\tname: \"bucket\"\n\t\tbase: {\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Bucket\"\n\t\t\tmetadata: name: \"test-bucket\"\n\n\t\t\t// Add fields here\n\t\t\tmetadata: annotations: {\n\t\t\t\t\"nobu.dev/cueified\": \"true\"\n\t\t\t\t\"nobu.dev/app\":      \"someapp\"\n\t\t\t}\n\n\t\t\tspec: forProvider: policy: \"some-bucket-policy\"\n\t\t}\n\t},\n\t{\n\t\tname: \"iam-user\"\n\t\tbase: {\n\t\t\t// Target the user by name\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"User\"\n\t\t\tmetadata: name: \"test-user\"\n\n\t\t\t// Add fields here\n\t\t\tmetadata: annotations: {\n\t\t\t\t\"nobu.dev/cueified\": \"true\"\n\t\t\t\t\"nobu.dev/app\":      \"someapp\"\n\t\t\t}\n\n\t\t\tspec: forProvider: name: \"somename\"\n\t\t}\n\t},\n\t{\n\t\tname: \"iam-role\"\n\t\tbase: {\n\t\t\t// Target the bucket by name\n\t\t\tapiVersion: \"nobu.dev/v1\"\n\t\t\tkind:       \"Role\"\n\t\t\tmetadata: name: \"test-role\"\n\n\t\t\t// Add fields here\n\t\t\tmetadata: annotations: {\n\t\t\t\t\"nobu.dev/cueified\": \"true\"\n\t\t\t\t\"nobu.dev/app\":      \"someapp\"\n\t\t\t}\n\n\t\t\tspec: forProvider: policy: \"some-role-policy\"\n\t\t}\n\t},\n]\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -1401,7 +1401,7 @@ func TestRunFunction(t *testing.T) {
 							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR"}`),
 						},
 						Resources: map[string]*fnv1beta1.Resource{
-							"test-bucket": {
+							"bucket": {
 								Resource: resource.MustStructJSON(`{
 									"apiVersion": "nobu.dev/v1",
 									"kind": "Bucket",
@@ -1419,7 +1419,7 @@ func TestRunFunction(t *testing.T) {
 									}
 								}`),
 							},
-							"test-user": {
+							"iam-user": {
 								Resource: resource.MustStructJSON(`{
 									"apiVersion": "nobu.dev/v1",
 									"kind": "User",
@@ -1437,7 +1437,7 @@ func TestRunFunction(t *testing.T) {
 									}
 								}`),
 							},
-							"test-role": {
+							"iam-role": {
 								Resource: resource.MustStructJSON(`{
 									"apiVersion": "nobu.dev/v1",
 									"kind": "Role",
@@ -1487,7 +1487,7 @@ func TestRunFunction(t *testing.T) {
 									"name": "example-cluster",
 									"base": {
 										"apiVersion": "nobu.dev/v1",
-										"kind": "findme",
+										"kind": "dontfindme",
 										"metadata": {
 											"name": "testname"
 										}
@@ -1504,7 +1504,7 @@ func TestRunFunction(t *testing.T) {
 									}
 								}
 							],
-							"value": "name: \"testname\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
+							"value": "name: \"example-nodepool\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -1529,12 +1529,12 @@ func TestRunFunction(t *testing.T) {
 							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR"}`),
 						},
 						Resources: map[string]*fnv1beta1.Resource{
-							"testname": {
+							"example-nodepool": {
 								Resource: resource.MustStructJSON(`{
 									"apiVersion": "nobu.dev/v1",
-									"kind": "findme",
+									"kind": "Cluster",
 									"metadata": {
-										"name": "testname"
+										"name": "dedpool"
 									},
 									"spec": {
 										"forProvider": {
@@ -1544,16 +1544,16 @@ func TestRunFunction(t *testing.T) {
 									}
 								}`),
 							},
-							"dedpool": {
+							"example-cluster": {
 								Resource: resource.MustStructJSON(`{
 									"apiVersion": "nobu.dev/v1",
-									"kind":       "Cluster",
+									"kind":       "dontfindme",
 									"metadata": {
-										"name": "dedpool"
+										"name": "testname"
 									}
 								}`),
 							},
-							"testnetwork": {
+							"example-network": {
 								Resource: resource.MustStructJSON(`{
 									"apiVersion": "nobu.dev/v1",
 									"kind": "Cluster",
@@ -1591,7 +1591,7 @@ func TestRunFunction(t *testing.T) {
 									}
 								}
 							],
-							"value": "name: \"testname\"\nconnectionDetails: [\n\t{\n\t\tName:                    \"testname\"\n\t\tType:                    \"FromConnectionSecretKey\"\n\t\tFromConnectionSecretKey: \"thisisthekey\"\n\t},\n]\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
+							"value": "name: \"example-cluster\"\nconnectionDetails: [\n\t{\n\t\tName:                    \"testname\"\n\t\tType:                    \"FromConnectionSecretKey\"\n\t\tFromConnectionSecretKey: \"thisisthekey\"\n\t},\n]\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -1633,7 +1633,7 @@ func TestRunFunction(t *testing.T) {
 							},
 						},
 						Resources: map[string]*fnv1beta1.Resource{
-							"testname": {
+							"example-cluster": {
 								Resource: resource.MustStructJSON(`{
 									"apiVersion": "nobu.dev/v1",
 									"kind": "findme",
@@ -1677,7 +1677,7 @@ func TestRunFunction(t *testing.T) {
 									}
 								}
 							],
-							"value": "name: \"testname\"\nreadinessChecks: [\n\t{\n\t\tType: \"MatchCondition\"\n\t\tMatchCondition: Type:   \"Ready\"\n\t\tMatchCondition: Status: \"True\"\n\t},\n]\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
+							"value": "name: \"example-cluster\"\nreadinessChecks: [\n\t{\n\t\tType: \"MatchCondition\"\n\t\tMatchCondition: Type:   \"Ready\"\n\t\tMatchCondition: Status: \"True\"\n\t},\n]\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: forProvider: router: \"somerouter\"\n\tspec: forProvider: region: \"ap-northeast-1\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -1685,7 +1685,7 @@ func TestRunFunction(t *testing.T) {
 							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR"}`),
 						},
 						Resources: map[string]*fnv1beta1.Resource{
-							"testname": {
+							"example-cluster": {
 								Resource: resource.MustStructJSON(`{
 									"apiVersion": "nobu.dev/v1",
 									"kind": "findme",
@@ -1728,7 +1728,7 @@ func TestRunFunction(t *testing.T) {
 							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR"}`),
 						},
 						Resources: map[string]*fnv1beta1.Resource{
-							"testname": {
+							"example-cluster": {
 								Resource: resource.MustStructJSON(`{
 									"apiVersion": "nobu.dev/v1",
 									"kind": "findme",
@@ -1827,7 +1827,7 @@ func TestRunFunctionFailures(t *testing.T) {
 									}
 								}
 							],
-							"value": "name: \"testname\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name:    \"testname\"\n\tspec: conflicting: \"setattempt\"\n}\n"
+							"value": "name: \"example-cluster\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name:    \"testname\"\n\tspec: conflicting: \"setattempt\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -1882,7 +1882,7 @@ func TestRunFunctionFailures(t *testing.T) {
 									}
 								}
 							],
-							"value": "name: \"testname\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: metadata: annotations: {\n\t\t\"rbac.authorization.k8s.io/autoupdate\": \"true\"\n\t}\n}\n"
+							"value": "name: \"example-cluster\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tspec: metadata: annotations: {\n\t\t\"rbac.authorization.k8s.io/autoupdate\": \"true\"\n\t}\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{
@@ -2000,7 +2000,7 @@ func TestRunFunctionFailures(t *testing.T) {
 			},
 		},
 		"FailMatchingMultipleTargets": {
-			reason: "PatchResources targeting should fail if gvk+name do not match",
+			reason: "PatchResources targeting should fail if name do not match",
 			args: args{
 				req: &fnv1beta1.RunFunctionRequest{
 					Input: resource.MustStructJSON(`{
@@ -2105,7 +2105,7 @@ func TestRunFunctionFailures(t *testing.T) {
 									}
 								}
 							],
-							"value": "name: \"testname\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tmetadata: annotations: \"kubernetes.io/serviceaccount\": \"newsa\"\n}\n"
+							"value": "name: \"example-cluster\"\nbase: {\n\tapiVersion: \"nobu.dev/v1\"\n\tkind:       \"findme\"\n\tmetadata: name: \"testname\"\n\tmetadata: annotations: \"kubernetes.io/serviceaccount\": \"newsa\"\n}\n"
 						}
 					}`),
 					Observed: &fnv1beta1.State{

--- a/ready.go
+++ b/ready.go
@@ -75,7 +75,7 @@ func reconcileReadiness(observed map[rresource.Name]rresource.ObservedComposed, 
 		for _, d := range data {
 			u := unstructured.Unstructured{Object: d.Base}
 			if u.GetName() == ocd.Resource.GetName() && u.GetAPIVersion() == ocd.Resource.GetAPIVersion() && u.GetKind() == ocd.Resource.GetKind() {
-				rc = append(rc, d.RedinessCheck)
+				rc = append(rc, d.RedinessChecks...)
 			}
 		}
 		return rc


### PR DESCRIPTION
### What and Why?

This updates the required output format per document for cueCompilation to be

```yaml
name: "name of resource"
# some connectionDetails for the resource
connectionDetails: []
# some readiness checks for the reasource
readinessChecks: []
base:
   apiVersion: "etc"
   ...
```

Fixes #48 

This also should make the overall function faster because it no longer needs to rely on the `#connectionDetails` and `#readinessChecks` within the cue template, because the values will be stored at a wrapped level of the original document (now stored in base) allowing these fields will be omitted or used if present in one parse without needing to run multiple compilations

This also now utilizes the `name` at the root of the document and allows for users to not have to specify `metadata.name` anymore.

This root `name` is now used to create resources as - `map[resource.Name($name)*DesiredComposed`, if there are multiple documents in the output the resource.Name is the `$CUEInput.Name-$name`

I have:

- [x] Read and followed the [Contribution guide](../docs/CONTRIBUTING.md).
- [x] Added or updated unit tests for my change.
