### PR TITLE
Add benchmarks and a detailed resource that generates 20 objs

### DIFF
--- a/cue_test.go
+++ b/cue_test.go
@@ -124,3 +124,43 @@ func TestCUECompileFailures(t *testing.T) {
 		assert.Equal(t, tv.Err, err.Error(), "%s: expected error %q: got %q", desc, tv.Err, err.Error())
 	}
 }
+
+// CUEInput.Export.Value(s) for benchmarks
+var benchTable = []string{
+	// Empty
+	"",
+	// def
+	"a: b: 5\na: c: 4",
+	// Operator
+	"out: 18 - 22",
+	// Operators
+	"out: 3 div 2",
+	// stdlib
+	"r: rem(-5, 2)",
+	// vars
+	"#test: \"somestring\"\n\nout: \"this-is-concatting-\\(#test)\"\n",
+	// package def
+	"package main\n\nenv:  string | *\"dev\" @tag(env)\nhost: \"\\(env).domain.com\"\n",
+	// loops
+	"[ for x in #items if __rem(x, 2) == 0 {x * x}]\n\n#items: [ 1, 2, 3, 4, 5, 6, 7, 8, 9]\n",
+	// imports
+	"import (\n\t\"math\"\n)\n\nout: math.Dim(50, 45)\n",
+}
+
+func benchmarkCUECompile(testIndex int, b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		// benchmarks run with outputJSON because that is the default for function-cue
+		// Streams output in outputTXT, these benchmarks are covered in fn_test.go
+		cueCompile(outputJSON, v1beta1.CUEInput{Export: v1beta1.Export{Value: benchTable[testIndex]}}, compileOpts{parseData: false})
+	}
+}
+
+func BenchmarkCUECompileEmpty(b *testing.B)        { benchmarkCUECompile(0, b) }
+func BenchmarkCUECompileBasic(b *testing.B)        { benchmarkCUECompile(1, b) }
+func BenchmarkCUECompileOperatorSub(b *testing.B)  { benchmarkCUECompile(2, b) }
+func BenchmarkCUECompileOperatorDiv(b *testing.B)  { benchmarkCUECompile(3, b) }
+func BenchmarkCUECompileStdlib(b *testing.B)       { benchmarkCUECompile(4, b) }
+func BenchmarkCUECompileVars(b *testing.B)         { benchmarkCUECompile(5, b) }
+func BenchmarkCUECompilePckageSchema(b *testing.B) { benchmarkCUECompile(6, b) }
+func BenchmarkCUECompileLoops(b *testing.B)        { benchmarkCUECompile(7, b) }
+func BenchmarkCUECompileImport(b *testing.B)       { benchmarkCUECompile(8, b) }

--- a/examples/resources/detailedresources/README.md
+++ b/examples/resources/detailedresources/README.md
@@ -1,0 +1,423 @@
+# [xrender](https://github.com/crossplane-contrib/xrender)
+
+#### Run
+```bash
+$ xrender xr.yaml composition.yaml functions.yaml
+```
+
+#### Produces
+```yaml
+---
+apiVersion: nopexample.org/v1
+kind: XCluster
+metadata:
+  name: test-xrender
+---
+apiVersion: nobu.dev/v1
+kind: XBucket
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: multiple-objects-bucket1
+  generateName: test-xrender-
+  labels:
+    crossplane.io/composite: test-xrender
+  ownerReferences:
+  - apiVersion: nopexample.org/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XCluster
+    name: test-xrender
+    uid: ""
+spec:
+  parameters:
+    policy: default-policy-arn
+---
+apiVersion: nobu.dev/v1
+kind: XNodepool
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: multiple-objects-someclass5-c512xlarge-3
+  generateName: test-xrender-
+  labels:
+    crossplane.io/composite: test-xrender
+  ownerReferences:
+  - apiVersion: nopexample.org/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XCluster
+    name: test-xrender
+    uid: ""
+spec:
+  parameters:
+    cluster: cluster-name
+    machineType: c5.12xlarge
+    region: us-east-2
+---
+apiVersion: nobu.dev/v1
+kind: XNodepool
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: multiple-objects-someclass3-m6gd4xlarge-1
+  generateName: test-xrender-
+  labels:
+    crossplane.io/composite: test-xrender
+  ownerReferences:
+  - apiVersion: nopexample.org/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XCluster
+    name: test-xrender
+    uid: ""
+spec:
+  parameters:
+    cluster: cluster-name
+    machineType: m6gd.4xlarge
+    region: us-east-2
+---
+apiVersion: nobu.dev/v1
+kind: XNodepool
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: multiple-objects-someclass2-m52xlarge-0
+  generateName: test-xrender-
+  labels:
+    crossplane.io/composite: test-xrender
+  ownerReferences:
+  - apiVersion: nopexample.org/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XCluster
+    name: test-xrender
+    uid: ""
+spec:
+  parameters:
+    cluster: cluster-name
+    machineType: m5.2xlarge
+    region: us-east-2
+---
+apiVersion: nobu.dev/v1
+kind: XBucket
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: multiple-objects-bucket2
+  generateName: test-xrender-
+  labels:
+    crossplane.io/composite: test-xrender
+  ownerReferences:
+  - apiVersion: nopexample.org/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XCluster
+    name: test-xrender
+    uid: ""
+spec:
+  parameters:
+    policy: default-policy-arn
+---
+apiVersion: nobu.dev/v1
+kind: XNodepool
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: multiple-objects-someclass4-c54xlarge-3
+  generateName: test-xrender-
+  labels:
+    crossplane.io/composite: test-xrender
+  ownerReferences:
+  - apiVersion: nopexample.org/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XCluster
+    name: test-xrender
+    uid: ""
+spec:
+  parameters:
+    cluster: cluster-name
+    machineType: c5.4xlarge
+    region: us-east-2
+---
+apiVersion: nobu.dev/v1
+kind: Cluster
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: multiple-objects-mycluster
+  generateName: test-xrender-
+  labels:
+    crossplane.io/composite: test-xrender
+  ownerReferences:
+  - apiVersion: nopexample.org/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XCluster
+    name: test-xrender
+    uid: ""
+spec:
+  forProvider:
+    name: cluster-name
+    region: us-east-2
+---
+apiVersion: nobu.dev/v1
+kind: XFirewall
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: multiple-objects-myfirewall
+  generateName: test-xrender-
+  labels:
+    crossplane.io/composite: test-xrender
+  ownerReferences:
+  - apiVersion: nopexample.org/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XCluster
+    name: test-xrender
+    uid: ""
+spec:
+  parameters:
+    region: us-east-2
+---
+apiVersion: nobu.dev/v1
+kind: XNodepool
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: multiple-objects-someclass5-c512xlarge-0
+  generateName: test-xrender-
+  labels:
+    crossplane.io/composite: test-xrender
+  ownerReferences:
+  - apiVersion: nopexample.org/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XCluster
+    name: test-xrender
+    uid: ""
+spec:
+  parameters:
+    cluster: cluster-name
+    machineType: c5.12xlarge
+    region: us-east-2
+---
+apiVersion: nobu.dev/v1
+kind: XNodepool
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: multiple-objects-someclass3-m6gd4xlarge-0
+  generateName: test-xrender-
+  labels:
+    crossplane.io/composite: test-xrender
+  ownerReferences:
+  - apiVersion: nopexample.org/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XCluster
+    name: test-xrender
+    uid: ""
+spec:
+  parameters:
+    cluster: cluster-name
+    machineType: m6gd.4xlarge
+    region: us-east-2
+---
+apiVersion: nobu.dev/v1
+kind: XNodepool
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: multiple-objects-someclass5-c512xlarge-2
+  generateName: test-xrender-
+  labels:
+    crossplane.io/composite: test-xrender
+  ownerReferences:
+  - apiVersion: nopexample.org/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XCluster
+    name: test-xrender
+    uid: ""
+spec:
+  parameters:
+    cluster: cluster-name
+    machineType: c5.12xlarge
+    region: us-east-2
+---
+apiVersion: nobu.dev/v1
+kind: XNodepool
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: multiple-objects-someclass4-c54xlarge-1
+  generateName: test-xrender-
+  labels:
+    crossplane.io/composite: test-xrender
+  ownerReferences:
+  - apiVersion: nopexample.org/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XCluster
+    name: test-xrender
+    uid: ""
+spec:
+  parameters:
+    cluster: cluster-name
+    machineType: c5.4xlarge
+    region: us-east-2
+---
+apiVersion: nobu.dev/v1
+kind: XBucket
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: multiple-objects-bucket3
+  generateName: test-xrender-
+  labels:
+    crossplane.io/composite: test-xrender
+  ownerReferences:
+  - apiVersion: nopexample.org/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XCluster
+    name: test-xrender
+    uid: ""
+spec:
+  parameters:
+    policy: default-policy-arn
+---
+apiVersion: nobu.dev/v1
+kind: XNodepool
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: multiple-objects-someclass5-c512xlarge-1
+  generateName: test-xrender-
+  labels:
+    crossplane.io/composite: test-xrender
+  ownerReferences:
+  - apiVersion: nopexample.org/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XCluster
+    name: test-xrender
+    uid: ""
+spec:
+  parameters:
+    cluster: cluster-name
+    machineType: c5.12xlarge
+    region: us-east-2
+---
+apiVersion: nobu.dev/v1
+kind: XVpc
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: multiple-objects-mynetwork
+  generateName: test-xrender-
+  labels:
+    crossplane.io/composite: test-xrender
+  ownerReferences:
+  - apiVersion: nopexample.org/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XCluster
+    name: test-xrender
+    uid: ""
+spec:
+  parameters:
+    region: us-east-2
+    visibility: private
+---
+apiVersion: nobu.dev/v1
+kind: XBucket
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: multiple-objects-bucket4
+  generateName: test-xrender-
+  labels:
+    crossplane.io/composite: test-xrender
+  ownerReferences:
+  - apiVersion: nopexample.org/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XCluster
+    name: test-xrender
+    uid: ""
+spec:
+  parameters:
+    policy: default-policy-arn
+---
+apiVersion: nobu.dev/v1
+kind: XNodepool
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: multiple-objects-someclass4-c54xlarge-0
+  generateName: test-xrender-
+  labels:
+    crossplane.io/composite: test-xrender
+  ownerReferences:
+  - apiVersion: nopexample.org/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XCluster
+    name: test-xrender
+    uid: ""
+spec:
+  parameters:
+    cluster: cluster-name
+    machineType: c5.4xlarge
+    region: us-east-2
+---
+apiVersion: nobu.dev/v1
+kind: XNodepool
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: multiple-objects-someclass5-c512xlarge-4
+  generateName: test-xrender-
+  labels:
+    crossplane.io/composite: test-xrender
+  ownerReferences:
+  - apiVersion: nopexample.org/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XCluster
+    name: test-xrender
+    uid: ""
+spec:
+  parameters:
+    cluster: cluster-name
+    machineType: c5.12xlarge
+    region: us-east-2
+---
+apiVersion: nobu.dev/v1
+kind: XNodepool
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: multiple-objects-someclass4-c54xlarge-2
+  generateName: test-xrender-
+  labels:
+    crossplane.io/composite: test-xrender
+  ownerReferences:
+  - apiVersion: nopexample.org/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XCluster
+    name: test-xrender
+    uid: ""
+spec:
+  parameters:
+    cluster: cluster-name
+    machineType: c5.4xlarge
+    region: us-east-2
+---
+apiVersion: nobu.dev/v1
+kind: XNodepool
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: multiple-objects-someclass-m5large-0
+  generateName: test-xrender-
+  labels:
+    crossplane.io/composite: test-xrender
+  ownerReferences:
+  - apiVersion: nopexample.org/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XCluster
+    name: test-xrender
+    uid: ""
+spec:
+  parameters:
+    cluster: cluster-name
+    machineType: m5.large
+    region: us-east-2
+```

--- a/examples/resources/detailedresources/composition.yaml
+++ b/examples/resources/detailedresources/composition.yaml
@@ -108,13 +108,13 @@ spec:
             for bucket in #Buckets {
               {
                 name: bucket.name
-                  resource: {
-                    apiVersion: #apiVersion
-                      kind:       "XBucket"
-                      spec: parameters: {
-                        policy: bucket.policy
-                      }
+                resource: {
+                  apiVersion: #apiVersion
+                  kind:       "XBucket"
+                  spec: parameters: {
+                    policy: bucket.policy
                   }
+                }
               }
             },
           ], 1)

--- a/examples/resources/detailedresources/composition.yaml
+++ b/examples/resources/detailedresources/composition.yaml
@@ -32,9 +32,9 @@ spec:
           #clusterName: "cluster-name"
           
           #NodeCount: {
-          classification: string
-          machineType:    string
-          count:          _
+            classification: string
+            machineType:    string
+            count:          _
           }
           
           #Nodepools: [...#NodeCount] & [
@@ -46,8 +46,8 @@ spec:
           ]
           
           #Bucket: {
-          name:   string
-          policy: "default-policy-arn"
+            name:   string
+            policy: "default-policy-arn"
           }
           
           #Buckets: [...#Bucket] & [
@@ -59,62 +59,62 @@ spec:
           
           output: list.FlattenN([
             {
-            name: "mycluster"
-            resource: {
-              apiVersion: #apiVersion
+              name: "mycluster"
+              resource: {
+                apiVersion: #apiVersion
                 kind:       "Cluster"
                 spec: forProvider: region: #region
                 spec: forProvider: name:   #clusterName
-            }
-          },
+              }
+            },
             {
               name: "mynetwork"
-                resource: {
-                  apiVersion: #apiVersion
-                    kind:       "XVpc"
-                    spec: parameters: region:     #region
-                    spec: parameters: visibility: "private"
-                }
+              resource: {
+                apiVersion: #apiVersion
+                kind:       "XVpc"
+                spec: parameters: region:     #region
+                spec: parameters: visibility: "private"
+              }
             },
             {
               name: "myfirewall"
-                resource: {
-                  apiVersion: #apiVersion
-                    kind:       "XFirewall"
-                    spec: parameters: region: #region
-                }
+              resource: {
+                apiVersion: #apiVersion
+                kind:       "XFirewall"
+                spec: parameters: region: #region
+              }
             },
           ]+[
             for nodepool in #Nodepools {
-            [
-              for i in list.Range(0, nodepool.count, 1) {
-              {
-                let #mT = strings.Replace(nodepool.machineType, ".", "", -1)
-                name: "\(nodepool.classification)-\(#mT)-\(i)"
-                  resource: {
-                    apiVersion: #apiVersion
+              [
+                for i in list.Range(0, nodepool.count, 1) {
+                  {
+                    let #mT = strings.Replace(nodepool.machineType, ".", "", -1)
+                    name: "\(nodepool.classification)-\(#mT)-\(i)"
+                    resource: {
+                      apiVersion: #apiVersion
                       kind:       "XNodepool"
                       spec: parameters: {
                         machineType: nodepool.machineType
-                          region:      #region
-                          cluster:     #clusterName
+                        region:      #region
+                        cluster:     #clusterName
+                      }
+                    }
+                  }
+                },
+              ]
+            },
+          ]+[
+            for bucket in #Buckets {
+              {
+                name: bucket.name
+                  resource: {
+                    apiVersion: #apiVersion
+                      kind:       "XBucket"
+                      spec: parameters: {
+                        policy: bucket.policy
                       }
                   }
               }
             },
-            ]
-          },
-          ]+[
-            for bucket in #Buckets {
-            {
-              name: bucket.name
-                resource: {
-                  apiVersion: #apiVersion
-                    kind:       "XBucket"
-                    spec: parameters: {
-                      policy: bucket.policy
-                    }
-                }
-            }
-          },
           ], 1)

--- a/examples/resources/detailedresources/composition.yaml
+++ b/examples/resources/detailedresources/composition.yaml
@@ -1,0 +1,120 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xnopresources.nop.example.org
+spec:
+  compositeTypeRef:
+    apiVersion: nop.example.org/v1alpha1
+    kind: XNopResource
+  mode: Pipeline
+  pipeline:
+  - step: conditional
+    functionRef:
+      name: function-cue
+    input:
+      apiVersion: cue.fn.crossplane.io/v1beta1
+      kind: CUEInput
+      metadata:
+        name: multiple-objects
+      export:
+        target: Resources
+        options:
+          expressions:
+          - yaml.MarshalStream(output)
+        value: |
+          import (
+            "list"
+            "strings"
+          )
+          
+          #apiVersion:  "nobu.dev/v1"
+          #region:      "us-east-2"
+          #clusterName: "cluster-name"
+          
+          #NodeCount: {
+          classification: string
+          machineType:    string
+          count:          _
+          }
+          
+          #Nodepools: [...#NodeCount] & [
+            {classification: "someclass", machineType:  "m5.large", count:     1},
+            {classification: "someclass2", machineType: "m5.2xlarge", count:   1},
+            {classification: "someclass3", machineType: "m6gd.4xlarge", count: 2},
+            {classification: "someclass4", machineType: "c5.4xlarge", count:   4},
+            {classification: "someclass5", machineType: "c5.12xlarge", count:  5},
+          ]
+          
+          #Bucket: {
+          name:   string
+          policy: "default-policy-arn"
+          }
+          
+          #Buckets: [...#Bucket] & [
+            {name: "bucket1"},
+            {name: "bucket2"},
+            {name: "bucket3"},
+            {name: "bucket4"},
+          ]
+          
+          output: list.FlattenN([
+            {
+            name: "mycluster"
+            resource: {
+              apiVersion: #apiVersion
+                kind:       "Cluster"
+                spec: forProvider: region: #region
+                spec: forProvider: name:   #clusterName
+            }
+          },
+            {
+              name: "mynetwork"
+                resource: {
+                  apiVersion: #apiVersion
+                    kind:       "XVpc"
+                    spec: parameters: region:     #region
+                    spec: parameters: visibility: "private"
+                }
+            },
+            {
+              name: "myfirewall"
+                resource: {
+                  apiVersion: #apiVersion
+                    kind:       "XFirewall"
+                    spec: parameters: region: #region
+                }
+            },
+          ]+[
+            for nodepool in #Nodepools {
+            [
+              for i in list.Range(0, nodepool.count, 1) {
+              {
+                let #mT = strings.Replace(nodepool.machineType, ".", "", -1)
+                name: "\(nodepool.classification)-\(#mT)-\(i)"
+                  resource: {
+                    apiVersion: #apiVersion
+                      kind:       "XNodepool"
+                      spec: parameters: {
+                        machineType: nodepool.machineType
+                          region:      #region
+                          cluster:     #clusterName
+                      }
+                  }
+              }
+            },
+            ]
+          },
+          ]+[
+            for bucket in #Buckets {
+            {
+              name: bucket.name
+                resource: {
+                  apiVersion: #apiVersion
+                    kind:       "XBucket"
+                    spec: parameters: {
+                      policy: bucket.policy
+                    }
+                }
+            }
+          },
+          ], 1)

--- a/examples/resources/detailedresources/functions.yaml
+++ b/examples/resources/detailedresources/functions.yaml
@@ -1,0 +1,1 @@
+../../functions.yaml

--- a/examples/resources/detailedresources/xr.yaml
+++ b/examples/resources/detailedresources/xr.yaml
@@ -1,0 +1,6 @@
+apiVersion: nopexample.org/v1
+kind: XCluster
+metadata:
+  name: test-xrender
+spec:
+  bucketRegion: us-east-2

--- a/examples/resources/detailedresources/xr.yaml
+++ b/examples/resources/detailedresources/xr.yaml
@@ -2,5 +2,3 @@ apiVersion: nopexample.org/v1
 kind: XCluster
 metadata:
   name: test-xrender
-spec:
-  bucketRegion: us-east-2

--- a/examples/resources/multipleresources/composition.yaml
+++ b/examples/resources/multipleresources/composition.yaml
@@ -23,39 +23,39 @@ spec:
           - yaml.MarshalStream(output)
         value: |
           output: [
-          	{
-                name: "example-cluster"
-                resource: {
-          	  	  apiVersion: "nobu.dev/v1"
-            	  kind:       "Cluster"
-                }
+            {
+              name: "example-cluster"
+              resource: {
+                apiVersion: "nobu.dev/v1"
+                kind:       "Cluster"
+              }
+            },
+            {
+              name: "example-network"
+              resource: {
+                apiVersion: "nobu.dev/v1"
+                kind:       "Network"
+              }
+            },
+            {
+              name: "example-memorystore"
+              resource: {
+                apiVersion: "nobu.dev/v1"
+                kind:       "Memorystore"
+              }
+            },
+            {
+              name: "example-firewalls"
+              resource: {
+                apiVersion: "nobu.dev/v1"
+                kind:       "Firewalls"
+              }
           	},
-          	{
-                name: "example-network"
-                resource: {
-          		  apiVersion: "nobu.dev/v1"
-          	  	  kind:       "Network"
-                }
-          	},
-          	{
-                name: "example-memorystore"
-                resource: {
-          		  apiVersion: "nobu.dev/v1"
-          		  kind:       "Memorystore"
-                }
-          	},
-          	{
-                name: "example-firewalls"
-                resource: {
-          	  	  apiVersion: "nobu.dev/v1"
-            	  kind:       "Firewalls"
-                }
-          	},
-          	{
-                name: "example-nodepools"
-                resource: {
-          		  apiVersion: "nobu.dev/v1"
-          		  kind:       "Nodepool"
-                }
-          	},
+            {
+              name: "example-nodepools"
+              resource: {
+                apiVersion: "nobu.dev/v1"
+                kind:       "Nodepool"
+              }
+            },
           ]

--- a/examples/resources/multipleresources/composition.yaml
+++ b/examples/resources/multipleresources/composition.yaml
@@ -50,7 +50,7 @@ spec:
                 apiVersion: "nobu.dev/v1"
                 kind:       "Firewalls"
               }
-          	},
+            },
             {
               name: "example-nodepools"
               resource: {


### PR DESCRIPTION
### What and Why?

This adds a couple of basic benchmarks.

```
$ go test -bench=.
goos: darwin
goarch: arm64
pkg: github.com/crossplane-contrib/function-cue
BenchmarkCUECompileEmpty-8          	     201	   5918794 ns/op
BenchmarkCUECompileBasic-8          	     199	   5979062 ns/op
BenchmarkCUECompileOperatorSub-8    	     201	   5930447 ns/op
BenchmarkCUECompileOperatorDiv-8    	     205	   5881755 ns/op
BenchmarkCUECompileStdlib-8         	     202	   5897504 ns/op
BenchmarkCUECompileVars-8           	     205	   6726373 ns/op
BenchmarkCUECompilePckageSchema-8   	     200	   5925658 ns/op
BenchmarkCUECompileLoops-8          	     198	   6778468 ns/op
BenchmarkCUECompileImport-8         	     194	   6508088 ns/op
BenchmarkRunFunctionBasic-8         	     200	   5859228 ns/op
BenchmarkRunFunctionStreamJSON-8    	     202	   5943220 ns/op
BenchmarkRunFunctionStreamYAML-8    	     196	   6020862 ns/op
BenchmarkRunFunctionIdentifier-8    	     196	   6087641 ns/op
BenchmarkRunFunction3Obj3Expr-8     	      66	  17945012 ns/op
BenchmarkRunFunction20Objs1Expr-8   	     130	   9124614 ns/op
```

I added benchmarks for cue compile, for basic cue compilation benchmarks and then for the function runs itself with a basic, streams, multiple expressions and one that generates 20 objs with 1 expression.  In general the slowness comes mostly from running multiple expressions as each expressions requires its own compilation.  This is reflected in the benchmark for `BenchmarkRunFunction3Obj3Expr`

I have:

- [x] Read and followed the [Contribution guide](../docs/CONTRIBUTING.md).
- [x] Added or updated unit tests for my change.
